### PR TITLE
Update to PK-Sim 10

### DIFF
--- a/Evaluation/Input/Content/Section2.3_Model_Parameters_and_Assumptions.md
+++ b/Evaluation/Input/Content/Section2.3_Model_Parameters_and_Assumptions.md
@@ -134,5 +134,5 @@ This is the result of the final parameter identification:
 | `Emax` P-gp                                                 | 2.5 FIXED (see [Section 2.2.1](#221-In-vitro-and-physicochemical-data)) |           |
 | `Emax` OATP1B1                                              | 0.383                                                        |           |
 
-<sup>*</sup> The value was set to 5.210 with the release of PK-Sim 10 to account for the updated calculation method of interstitial concentrations (please refer to the respective [release notes of version 10](https://github.com/Open-Systems-Pharmacology/Suite/releases/tag/v10.0)).
+<sup>*</sup> The value in the model was updated to 5.210 with the release of PK-Sim 10 to account for the updated calculation method of interstitial concentrations (please refer to the respective [release notes of version 10](https://github.com/Open-Systems-Pharmacology/Suite/releases/tag/v10.0)).
 

--- a/Evaluation/Input/Content/Section2.3_Model_Parameters_and_Assumptions.md
+++ b/Evaluation/Input/Content/Section2.3_Model_Parameters_and_Assumptions.md
@@ -129,11 +129,10 @@ This is the result of the final parameter identification:
 | `Solubility at reference pH`                                | 2800 FIXED (see [Section 2.2.1](#221-In-vitro-and-physicochemical-data)) | mg/L      |
 | `kcat` AADAC (with a reference concentration of 1 µmol/L)   | 9.865                                                        | 1/min     |
 | `kcat` P-gp (with a reference concentration of 1.41 µmol/L) | 0.6088                                                       | 1/min     |
-| `kcat` OATP1B1 (with a reference concentration of 1 µmol/L) | 7.796                                                        | 1/min     |
+| `kcat` OATP1B1 (with a reference concentration of 1 µmol/L) | 7.796<sup>*</sup>                                            | 1/min     |
 | `Emax` AADAC                                                | 0.985                                                        |           |
 | `Emax` P-gp                                                 | 2.5 FIXED (see [Section 2.2.1](#221-In-vitro-and-physicochemical-data)) |           |
 | `Emax` OATP1B1                                              | 0.383                                                        |           |
 
-
-
+<sup>*</sup> The value was set to 5.210 with the release of PK-Sim 10 to account for the updated calculation method of interstitial concentrations (please refer to the respective [release notes of version 10](https://github.com/Open-Systems-Pharmacology/Suite/releases/tag/v10)).
 

--- a/Evaluation/Input/Content/Section2.3_Model_Parameters_and_Assumptions.md
+++ b/Evaluation/Input/Content/Section2.3_Model_Parameters_and_Assumptions.md
@@ -134,5 +134,5 @@ This is the result of the final parameter identification:
 | `Emax` P-gp                                                 | 2.5 FIXED (see [Section 2.2.1](#221-In-vitro-and-physicochemical-data)) |           |
 | `Emax` OATP1B1                                              | 0.383                                                        |           |
 
-<sup>*</sup> The value was set to 5.210 with the release of PK-Sim 10 to account for the updated calculation method of interstitial concentrations (please refer to the respective [release notes of version 10](https://github.com/Open-Systems-Pharmacology/Suite/releases/tag/v10)).
+<sup>*</sup> The value was set to 5.210 with the release of PK-Sim 10 to account for the updated calculation method of interstitial concentrations (please refer to the respective [release notes of version 10](https://github.com/Open-Systems-Pharmacology/Suite/releases/tag/v10.0)).
 

--- a/Evaluation/Workflow.m
+++ b/Evaluation/Workflow.m
@@ -5,10 +5,15 @@
 close all
 tic
 
+if exist(fullfile(cd,'re_input'),'dir')>0 rmdir(fullfile(cd,'re_input'),'s'); end
+if exist(fullfile(cd,'re_output'),'dir')>0 rmdir(fullfile(cd,'re_output'),'s'); end
+if exist(fullfile(cd,'report'),'dir')>0 rmdir(fullfile(cd,'report'),'s'); end
+
 % --------------------------------------------------------------
 % replace qualificationRunnerFolder and markdownJoinerFolder with your paths
-qualificationRunnerFolder = 'C:\Software\QualificationRunner 8.0.51';
+qualificationRunnerFolder = 'C:\Software\QualificationRunner';
 markdownJoinerFolder = 'C:\Software\markdown-joiner';
+PKSimPortableFolder = 'C:\Software\PKSimPortable';
 
 % --------------------------------------------------------------
 % replace baseDir and qualificationPlanName with your paths
@@ -42,7 +47,7 @@ ReportOutput_path=fullfile(baseDir,'report');
 
 % --------------------------------------------------------------
 % STEP #1: start qualification runner to generate inputs for the reporting engine
-startQualificationRunner(qualificationRunnerFolder, qualificationPlan, REInput_path);
+startQualificationRunner(qualificationRunnerFolder, qualificationPlan, REInput_path, ['-p ' PKSimPortableFolder]);
 
 % --------------------------------------------------------------
 % STEP #2: start reporting engine

--- a/Rifampicin-Model.json
+++ b/Rifampicin-Model.json
@@ -2775,15 +2775,15 @@
               "Unit": "µmol/l",
               "ValueOrigin": {
                 "Source": "Publication",
-                "Description": "Dose-Response-Calibration"
+                "Description": "Templeton 2011 (weighted mean for FHH)"
               }
             },
             {
               "Name": "Emax",
               "Value": 9.0,
               "ValueOrigin": {
-                "Source": "ParameterIdentification",
-                "Description": "Dose-Response-Calibration"
+                "Source": "Publication",
+                "Description": "Templeton 2011 (weighted mean for FHH)"
               }
             }
           ]

--- a/Rifampicin-Model.json
+++ b/Rifampicin-Model.json
@@ -1,5 +1,5 @@
 {
-  "Version": 76,
+  "Version": 78,
   "Individuals": [
     {
       "Name": "European (P-gp modified, CYP3A4 36 h)",
@@ -19,192 +19,522 @@
       },
       "Parameters": [
         {
+          "Path": "AADAC|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "AADAC|Relative expression in blood cells",
+          "Value": 3.9102564103E-05
+        },
+        {
+          "Path": "AADAC|Relative expression in plasma",
+          "Value": 3.9102564103E-05
+        },
+        {
+          "Path": "AADAC|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "AADAC|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ATP1A2|Reference concentration",
+          "Value": 0.39140774,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ATP1A2|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "GABRG2|Reference concentration",
+          "Value": 1.04099689,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "GABRG2|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "GABRG2|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "OATP1B1|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|AADAC|Relative expression",
+          "Value": 4.8717948718E-05
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0062154033171
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|P-gp|Relative expression",
+          "Value": 0.0242518189
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|AADAC|Relative expression",
+          "Value": 3.9743589744E-05
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|ATP1A2|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|GABRG2|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.00014166666667
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|P-gp|Relative expression",
+          "Value": 0.07608904
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|AADAC|Relative expression",
+          "Value": 0.0011923076923
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0508741242
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.0141666667
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|P-gp|Relative expression",
+          "Value": 0.017417973
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|AADAC|Relative expression",
+          "Value": 0.0026602564103
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.3179118843
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.0008253968254
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|P-gp|Relative expression",
+          "Value": 0.0419198106
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|AADAC|Relative expression",
+          "Value": 5.7051282051E-05
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0158938619
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|P-gp|Relative expression",
+          "Value": 0.7092198582
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|P-gp|Relative expression",
+          "Value": 0.1108416465
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
           "Path": "Organism|Liver|EHC continuous fraction",
           "Value": 1.0,
           "ValueOrigin": {
             "Source": "Unknown"
           }
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|AADAC|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0223784807
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|OATP1B1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|P-gp|Relative expression",
+          "Value": 0.1916810428
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|UGT1A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|AADAC|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0223784807
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|OATP1B1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|P-gp|Relative expression",
+          "Value": 0.1916810428
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|UGT1A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|AADAC|Relative expression",
+          "Value": 0.0269230769
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0272345453
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|OATP1B1|Relative expression",
+          "Value": 4.0079365079E-05
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|P-gp|Relative expression",
+          "Value": 0.0657549316
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|AADAC|Relative expression",
+          "Value": 0.00020833333333
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.7034193524
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.00064682539683
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|P-gp|Relative expression",
+          "Value": 0.0128342959
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|AADAC|Relative expression",
+          "Value": 0.1474358974
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0073903254795
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|P-gp|Relative expression",
+          "Value": 0.0142510689
+        },
+        {
+          "Path": "Organism|Skin|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0389467988
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|P-gp|Relative expression",
+          "Value": 0.2808543974
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|AADAC|Relative expression",
+          "Value": 0.00037115384615
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0103243118
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|P-gp|Relative expression",
+          "Value": 0.0742555691
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|AADAC|Relative expression",
+          "Value": 0.0775641026
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0309435884
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|P-gp|Relative expression",
+          "Value": 0.0260852897
+        },
+        {
+          "Path": "P-gp|Reference concentration",
+          "Value": 1.41,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "P-gp|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "P-gp|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "UGT1A4|Reference concentration",
+          "Value": 2.32,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "UGT1A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "UGT1A4|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
         }
       ],
       "Molecules": [
         {
           "Name": "CYP3A4",
           "Type": "Enzyme",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "Intracellular",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "Brain",
-              "Value": 0.0041682898325
-            },
-            {
-              "Name": "Gonads",
-              "Value": 0.00078691079081
-            },
-            {
-              "Name": "Kidney",
-              "Value": 0.0053603428126
-            },
-            {
-              "Name": "Periportal",
-              "Value": 1.0
-            },
-            {
-              "Name": "Pericentral",
-              "Value": 1.0
-            },
-            {
-              "Name": "Lung",
-              "Value": 0.00042695753798
-            },
-            {
-              "Name": "SmallIntestine",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "Duodenum",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "UpperJejunum",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "LowerJejunum",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "UpperIleum",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "LowerIleum",
-              "Value": 0.0727697702
-            }
-          ],
+          "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
           "Ontogeny": {
             "Name": "CYP3A4"
-          },
-          "Parameters": [
-            {
-              "Name": "t1/2 (liver)",
-              "Value": 36.0,
-              "Unit": "h",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            }
-          ]
+          }
         },
         {
           "Name": "AADAC",
           "Type": "Enzyme",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "Intracellular",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "BloodCells",
-              "Value": 3.9102564103E-05
-            },
-            {
-              "Name": "Plasma",
-              "Value": 3.9102564103E-05
-            },
-            {
-              "Name": "Bone",
-              "Value": 4.8717948718E-05
-            },
-            {
-              "Name": "Brain",
-              "Value": 3.9743589744E-05
-            },
-            {
-              "Name": "Gonads",
-              "Value": 0.0011923076923
-            },
-            {
-              "Name": "Heart",
-              "Value": 0.0026602564103
-            },
-            {
-              "Name": "Kidney",
-              "Value": 5.7051282051E-05
-            },
-            {
-              "Name": "Periportal",
-              "Value": 1.0
-            },
-            {
-              "Name": "Pericentral",
-              "Value": 1.0
-            },
-            {
-              "Name": "Lung",
-              "Value": 0.0269230769
-            },
-            {
-              "Name": "Muscle",
-              "Value": 0.00020833333333
-            },
-            {
-              "Name": "Pancreas",
-              "Value": 0.1474358974
-            },
-            {
-              "Name": "Spleen",
-              "Value": 0.00037115384615
-            },
-            {
-              "Name": "Stomach",
-              "Value": 0.0775641026
-            },
-            {
-              "Name": "SmallIntestine",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "LargeIntestine",
-              "Value": 0.00010384615385
-            },
-            {
-              "Name": "Duodenum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "UpperJejunum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "LowerJejunum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "UpperIleum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "LowerIleum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "ColonAscendens",
-              "Value": 0.00010384615385
-            },
-            {
-              "Name": "ColonTransversum",
-              "Value": 0.00010384615385
-            },
-            {
-              "Name": "ColonDescendens",
-              "Value": 0.00010384615385
-            },
-            {
-              "Name": "ColonSigmoid",
-              "Value": 0.00010384615385
-            }
-          ]
+          "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
         },
         {
           "Name": "P-gp",
@@ -213,118 +543,221 @@
           "Expression": [
             {
               "Name": "Bone",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0341950646
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Brain",
-              "MembraneLocation": "BloodBrainBarrier",
-              "Value": 0.1072855464
+              "TransportDirection": "EffluxBrainInterstitialToPlasma",
+              "CompartmentName": "Plasma"
+            },
+            {
+              "Name": "Brain",
+              "TransportDirection": "EffluxBrainTissueToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Fat",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Gonads",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.024559342
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Heart",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.059106933
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Kidney",
-              "MembraneLocation": "Apical",
-              "Value": 1.0
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
             },
             {
-              "Name": "Periportal",
-              "MembraneLocation": "Apical",
-              "Value": 0.2702702703
-            },
-            {
-              "Name": "Pericentral",
-              "MembraneLocation": "Apical",
-              "Value": 0.2702702703
-            },
-            {
-              "Name": "Lung",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0927144536
-            },
-            {
-              "Name": "Muscle",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0180963572
-            },
-            {
-              "Name": "Pancreas",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0200940071
-            },
-            {
-              "Name": "Spleen",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.1047003525
+              "Name": "Kidney",
+              "TransportDirection": "ExcretionKidney",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Stomach",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0367802585
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "SmallIntestine",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.3960047004
-            },
-            {
-              "Name": "LargeIntestine",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.1562867215
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Duodenum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Duodenum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "UpperJejunum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "UpperJejunum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "LowerJejunum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "LowerJejunum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "UpperIleum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "UpperIleum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "LowerIleum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "LowerIleum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "LargeIntestine",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Caecum",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Caecum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "ColonAscendens",
-              "MembraneLocation": "Apical",
-              "Value": 0.56
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonAscendens",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "ColonTransversum",
-              "MembraneLocation": "Apical",
-              "Value": 0.56
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonTransversum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "ColonDescendens",
-              "MembraneLocation": "Apical",
-              "Value": 0.56
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonDescendens",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "ColonSigmoid",
-              "MembraneLocation": "Apical",
-              "Value": 0.56
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonSigmoid",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Rectum",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Rectum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Periportal",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Periportal",
+              "TransportDirection": "ExcretionLiver",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Pericentral",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Pericentral",
+              "TransportDirection": "ExcretionLiver",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Lung",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Muscle",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Pancreas",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Skin",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Spleen",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "BloodCells",
+              "TransportDirection": "EffluxBloodCellsToPlasma"
+            },
+            {
+              "Name": "VascularEndothelium",
+              "TransportDirection": "EffluxInterstitialToPlasma"
             }
           ],
           "Ontogeny": {
@@ -583,17 +1016,7 @@
                 }
               ]
             }
-          },
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 1.41,
-              "Unit": "µmol/l",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            }
-          ]
+          }
         },
         {
           "Name": "OATP1B1",
@@ -601,209 +1024,242 @@
           "TransportType": "Influx",
           "Expression": [
             {
+              "Name": "Bone",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
               "Name": "Brain",
-              "MembraneLocation": "BloodBrainBarrier",
-              "Value": 0.00014166666667
+              "TransportDirection": "InfluxBrainPlasmaToInterstitial",
+              "CompartmentName": "Plasma"
+            },
+            {
+              "Name": "Brain",
+              "TransportDirection": "InfluxBrainInterstitialToTissue",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Fat",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Gonads",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0141666667
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Heart",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0008253968254
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Kidney",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Kidney",
+              "TransportDirection": "ExcretionKidney",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Stomach",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "SmallIntestine",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Duodenum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Duodenum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "UpperJejunum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "UpperJejunum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "LowerJejunum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "LowerJejunum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "UpperIleum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "UpperIleum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "LowerIleum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "LowerIleum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "LargeIntestine",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Caecum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Caecum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "ColonAscendens",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonAscendens",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "ColonTransversum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonTransversum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "ColonDescendens",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonDescendens",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "ColonSigmoid",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonSigmoid",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Rectum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Rectum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Periportal",
-              "MembraneLocation": "Basolateral",
-              "Value": 1.0
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Periportal",
+              "TransportDirection": "ExcretionLiver",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Pericentral",
-              "MembraneLocation": "Basolateral",
-              "Value": 1.0
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Pericentral",
+              "TransportDirection": "ExcretionLiver",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Lung",
-              "MembraneLocation": "Basolateral",
-              "Value": 4.0079365079E-05
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Muscle",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.00064682539683
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Pancreas",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Skin",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Spleen",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "BloodCells",
+              "TransportDirection": "InfluxPlasmaToBloodCells"
+            },
+            {
+              "Name": "VascularEndothelium",
+              "TransportDirection": "InfluxPlasmaToInterstitial"
             }
           ]
         },
         {
           "Name": "ATP1A2",
           "Type": "OtherProtein",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "ExtracellularMembrane",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "Bone",
-              "Value": 0.0062154033171
-            },
-            {
-              "Name": "Brain",
-              "Value": 1.0
-            },
-            {
-              "Name": "Gonads",
-              "Value": 0.0508741242
-            },
-            {
-              "Name": "Heart",
-              "Value": 0.3179118843
-            },
-            {
-              "Name": "Kidney",
-              "Value": 0.0158938619
-            },
-            {
-              "Name": "Periportal",
-              "Value": 0.0223784807
-            },
-            {
-              "Name": "Pericentral",
-              "Value": 0.0223784807
-            },
-            {
-              "Name": "Lung",
-              "Value": 0.0272345453
-            },
-            {
-              "Name": "Muscle",
-              "Value": 0.7034193524
-            },
-            {
-              "Name": "Pancreas",
-              "Value": 0.0073903254795
-            },
-            {
-              "Name": "Skin",
-              "Value": 0.0389467988
-            },
-            {
-              "Name": "Spleen",
-              "Value": 0.0103243118
-            },
-            {
-              "Name": "Stomach",
-              "Value": 0.0309435884
-            },
-            {
-              "Name": "SmallIntestine",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "LargeIntestine",
-              "Value": 0.0786998764
-            },
-            {
-              "Name": "Duodenum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "UpperJejunum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "LowerJejunum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "UpperIleum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "LowerIleum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "ColonAscendens",
-              "Value": 0.0786998764
-            },
-            {
-              "Name": "ColonTransversum",
-              "Value": 0.0786998764
-            },
-            {
-              "Name": "ColonDescendens",
-              "Value": 0.0786998764
-            },
-            {
-              "Name": "ColonSigmoid",
-              "Value": 0.0786998764
-            }
-          ],
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 0.47661714,
-              "Unit": "µmol/l",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            }
-          ]
+          "Localization": "Interstitial, BloodCellsMembrane, VascMembranePlasmaSide"
         },
         {
           "Name": "UGT1A4",
           "Type": "Enzyme",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "Intracellular",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "Periportal",
-              "Value": 1.0
-            },
-            {
-              "Name": "Pericentral",
-              "Value": 1.0
-            }
-          ],
+          "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
           "Ontogeny": {
             "Name": "UGT1A4"
-          },
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 2.32,
-              "Unit": "µmol/l",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            }
-          ]
+          }
         },
         {
           "Name": "GABRG2",
           "Type": "OtherProtein",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "ExtracellularMembrane",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "Brain",
-              "Value": 1.0
-            }
-          ],
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 1.0877710492,
-              "Unit": "µmol/l",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            }
-          ]
+          "Localization": "Interstitial, BloodCellsMembrane, VascMembranePlasmaSide"
         }
       ]
     },
@@ -823,185 +1279,517 @@
           "Unit": "year(s)"
         }
       },
+      "Parameters": [
+        {
+          "Path": "AADAC|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "AADAC|Relative expression in blood cells",
+          "Value": 3.9102564103E-05
+        },
+        {
+          "Path": "AADAC|Relative expression in plasma",
+          "Value": 3.9102564103E-05
+        },
+        {
+          "Path": "AADAC|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "AADAC|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ATP1A2|Reference concentration",
+          "Value": 0.39140774,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "ATP1A2|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "ATP1A2|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|Reference concentration",
+          "Value": 4.32,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "CYP3A4|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "GABRG2|Reference concentration",
+          "Value": 1.04099689,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "GABRG2|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "GABRG2|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "OATP1B1|Reference concentration",
+          "Value": 1.0,
+          "Unit": "µmol/l"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "OATP1B1|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|AADAC|Relative expression",
+          "Value": 4.8717948718E-05
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0062154033171
+        },
+        {
+          "Path": "Organism|Bone|Intracellular|P-gp|Relative expression",
+          "Value": 0.0242518189
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|AADAC|Relative expression",
+          "Value": 3.9743589744E-05
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|ATP1A2|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0041682898325
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|GABRG2|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.00014166666667
+        },
+        {
+          "Path": "Organism|Brain|Intracellular|P-gp|Relative expression",
+          "Value": 0.07608904
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|AADAC|Relative expression",
+          "Value": 0.0011923076923
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0508741242
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00078691079081
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.0141666667
+        },
+        {
+          "Path": "Organism|Gonads|Intracellular|P-gp|Relative expression",
+          "Value": 0.017417973
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|AADAC|Relative expression",
+          "Value": 0.0026602564103
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.3179118843
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.0008253968254
+        },
+        {
+          "Path": "Organism|Heart|Intracellular|P-gp|Relative expression",
+          "Value": 0.0419198106
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|AADAC|Relative expression",
+          "Value": 5.7051282051E-05
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0158938619
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0053603428126
+        },
+        {
+          "Path": "Organism|Kidney|Intracellular|P-gp|Relative expression",
+          "Value": 0.7092198582
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Intracellular|P-gp|Relative expression",
+          "Value": 0.1108416465
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|AADAC|Relative expression",
+          "Value": 0.00010384615385
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0786998764
+        },
+        {
+          "Path": "Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+          "Value": 0.3971631206
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|AADAC|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0223784807
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|OATP1B1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|P-gp|Relative expression",
+          "Value": 0.1916810428
+        },
+        {
+          "Path": "Organism|Liver|Pericentral|Intracellular|UGT1A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|AADAC|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0223784807
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|CYP3A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|OATP1B1|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|P-gp|Relative expression",
+          "Value": 0.1916810428
+        },
+        {
+          "Path": "Organism|Liver|Periportal|Intracellular|UGT1A4|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|AADAC|Relative expression",
+          "Value": 0.0269230769
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0272345453
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.00042695753798
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|OATP1B1|Relative expression",
+          "Value": 4.0079365079E-05
+        },
+        {
+          "Path": "Organism|Lung|Intracellular|P-gp|Relative expression",
+          "Value": 0.0657549316
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|AADAC|Relative expression",
+          "Value": 0.00020833333333
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.7034193524
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|OATP1B1|Relative expression",
+          "Value": 0.00064682539683
+        },
+        {
+          "Path": "Organism|Muscle|Intracellular|P-gp|Relative expression",
+          "Value": 0.0128342959
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|AADAC|Relative expression",
+          "Value": 0.1474358974
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0073903254795
+        },
+        {
+          "Path": "Organism|Pancreas|Intracellular|P-gp|Relative expression",
+          "Value": 0.0142510689
+        },
+        {
+          "Path": "Organism|Skin|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0389467988
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Intracellular|P-gp|Relative expression",
+          "Value": 0.2808543974
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|AADAC|Relative expression",
+          "Value": 0.2544871795
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0501579923
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Relative expression",
+          "Value": 0.0727697702
+        },
+        {
+          "Path": "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+          "Value": 1.0
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|AADAC|Relative expression",
+          "Value": 0.00037115384615
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0103243118
+        },
+        {
+          "Path": "Organism|Spleen|Intracellular|P-gp|Relative expression",
+          "Value": 0.0742555691
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|AADAC|Relative expression",
+          "Value": 0.0775641026
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|ATP1A2|Relative expression",
+          "Value": 0.0309435884
+        },
+        {
+          "Path": "Organism|Stomach|Intracellular|P-gp|Relative expression",
+          "Value": 0.0260852897
+        },
+        {
+          "Path": "P-gp|Reference concentration",
+          "Value": 1.41,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "P-gp|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "P-gp|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "UGT1A4|Reference concentration",
+          "Value": 2.32,
+          "Unit": "µmol/l",
+          "ValueOrigin": {
+            "Source": "Unknown"
+          }
+        },
+        {
+          "Path": "UGT1A4|t1/2 (intestine)",
+          "Value": 23.0,
+          "Unit": "h"
+        },
+        {
+          "Path": "UGT1A4|t1/2 (liver)",
+          "Value": 36.0,
+          "Unit": "h"
+        }
+      ],
       "Molecules": [
         {
           "Name": "CYP3A4",
           "Type": "Enzyme",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "Intracellular",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "Brain",
-              "Value": 0.0041682898325
-            },
-            {
-              "Name": "Gonads",
-              "Value": 0.00078691079081
-            },
-            {
-              "Name": "Kidney",
-              "Value": 0.0053603428126
-            },
-            {
-              "Name": "Periportal",
-              "Value": 1.0
-            },
-            {
-              "Name": "Pericentral",
-              "Value": 1.0
-            },
-            {
-              "Name": "Lung",
-              "Value": 0.00042695753798
-            },
-            {
-              "Name": "SmallIntestine",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "Duodenum",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "UpperJejunum",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "LowerJejunum",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "UpperIleum",
-              "Value": 0.0727697702
-            },
-            {
-              "Name": "LowerIleum",
-              "Value": 0.0727697702
-            }
-          ],
+          "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
           "Ontogeny": {
             "Name": "CYP3A4"
-          },
-          "Parameters": [
-            {
-              "Name": "t1/2 (liver)",
-              "Value": 36.0,
-              "Unit": "h",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            }
-          ]
+          }
         },
         {
           "Name": "AADAC",
           "Type": "Enzyme",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "Intracellular",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "BloodCells",
-              "Value": 3.9102564103E-05
-            },
-            {
-              "Name": "Plasma",
-              "Value": 3.9102564103E-05
-            },
-            {
-              "Name": "Bone",
-              "Value": 4.8717948718E-05
-            },
-            {
-              "Name": "Brain",
-              "Value": 3.9743589744E-05
-            },
-            {
-              "Name": "Gonads",
-              "Value": 0.0011923076923
-            },
-            {
-              "Name": "Heart",
-              "Value": 0.0026602564103
-            },
-            {
-              "Name": "Kidney",
-              "Value": 5.7051282051E-05
-            },
-            {
-              "Name": "Periportal",
-              "Value": 1.0
-            },
-            {
-              "Name": "Pericentral",
-              "Value": 1.0
-            },
-            {
-              "Name": "Lung",
-              "Value": 0.0269230769
-            },
-            {
-              "Name": "Muscle",
-              "Value": 0.00020833333333
-            },
-            {
-              "Name": "Pancreas",
-              "Value": 0.1474358974
-            },
-            {
-              "Name": "Spleen",
-              "Value": 0.00037115384615
-            },
-            {
-              "Name": "Stomach",
-              "Value": 0.0775641026
-            },
-            {
-              "Name": "SmallIntestine",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "LargeIntestine",
-              "Value": 0.00010384615385
-            },
-            {
-              "Name": "Duodenum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "UpperJejunum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "LowerJejunum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "UpperIleum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "LowerIleum",
-              "Value": 0.2544871795
-            },
-            {
-              "Name": "ColonAscendens",
-              "Value": 0.00010384615385
-            },
-            {
-              "Name": "ColonTransversum",
-              "Value": 0.00010384615385
-            },
-            {
-              "Name": "ColonDescendens",
-              "Value": 0.00010384615385
-            },
-            {
-              "Name": "ColonSigmoid",
-              "Value": 0.00010384615385
-            }
-          ]
+          "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome"
         },
         {
           "Name": "P-gp",
@@ -1010,118 +1798,221 @@
           "Expression": [
             {
               "Name": "Bone",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0341950646
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Brain",
-              "MembraneLocation": "BloodBrainBarrier",
-              "Value": 0.1072855464
+              "TransportDirection": "EffluxBrainInterstitialToPlasma",
+              "CompartmentName": "Plasma"
+            },
+            {
+              "Name": "Brain",
+              "TransportDirection": "EffluxBrainTissueToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Fat",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Gonads",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.024559342
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Heart",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.059106933
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Kidney",
-              "MembraneLocation": "Apical",
-              "Value": 1.0
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
             },
             {
-              "Name": "Periportal",
-              "MembraneLocation": "Apical",
-              "Value": 0.2702702703
-            },
-            {
-              "Name": "Pericentral",
-              "MembraneLocation": "Apical",
-              "Value": 0.2702702703
-            },
-            {
-              "Name": "Lung",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0927144536
-            },
-            {
-              "Name": "Muscle",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0180963572
-            },
-            {
-              "Name": "Pancreas",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0200940071
-            },
-            {
-              "Name": "Spleen",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.1047003525
+              "Name": "Kidney",
+              "TransportDirection": "ExcretionKidney",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Stomach",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0367802585
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "SmallIntestine",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.3960047004
-            },
-            {
-              "Name": "LargeIntestine",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.1562867215
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Duodenum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Duodenum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "UpperJejunum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "UpperJejunum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "LowerJejunum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "LowerJejunum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "UpperIleum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "UpperIleum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "LowerIleum",
-              "MembraneLocation": "Apical",
-              "Value": 1.41
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "LowerIleum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "LargeIntestine",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Caecum",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Caecum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "ColonAscendens",
-              "MembraneLocation": "Apical",
-              "Value": 0.56
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonAscendens",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "ColonTransversum",
-              "MembraneLocation": "Apical",
-              "Value": 0.56
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonTransversum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "ColonDescendens",
-              "MembraneLocation": "Apical",
-              "Value": 0.56
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonDescendens",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "ColonSigmoid",
-              "MembraneLocation": "Apical",
-              "Value": 0.56
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonSigmoid",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Rectum",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Rectum",
+              "TransportDirection": "EffluxMucosaIntracellularToLumen",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Periportal",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Periportal",
+              "TransportDirection": "ExcretionLiver",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Pericentral",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Pericentral",
+              "TransportDirection": "ExcretionLiver",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Lung",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Muscle",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Pancreas",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Skin",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Spleen",
+              "TransportDirection": "EffluxIntracellularToInterstitial",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "BloodCells",
+              "TransportDirection": "EffluxBloodCellsToPlasma"
+            },
+            {
+              "Name": "VascularEndothelium",
+              "TransportDirection": "EffluxInterstitialToPlasma"
             }
           ],
           "Ontogeny": {
@@ -1380,17 +2271,7 @@
                 }
               ]
             }
-          },
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 1.41,
-              "Unit": "µmol/l",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            }
-          ]
+          }
         },
         {
           "Name": "OATP1B1",
@@ -1398,209 +2279,242 @@
           "TransportType": "Influx",
           "Expression": [
             {
+              "Name": "Bone",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
               "Name": "Brain",
-              "MembraneLocation": "BloodBrainBarrier",
-              "Value": 0.00014166666667
+              "TransportDirection": "InfluxBrainPlasmaToInterstitial",
+              "CompartmentName": "Plasma"
+            },
+            {
+              "Name": "Brain",
+              "TransportDirection": "InfluxBrainInterstitialToTissue",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Fat",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Gonads",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0141666667
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Heart",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.0008253968254
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Kidney",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Kidney",
+              "TransportDirection": "ExcretionKidney",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Stomach",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "SmallIntestine",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Duodenum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Duodenum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "UpperJejunum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "UpperJejunum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "LowerJejunum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "LowerJejunum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "UpperIleum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "UpperIleum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "LowerIleum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "LowerIleum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "LargeIntestine",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Caecum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Caecum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "ColonAscendens",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonAscendens",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "ColonTransversum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonTransversum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "ColonDescendens",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonDescendens",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "ColonSigmoid",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "ColonSigmoid",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Rectum",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Rectum",
+              "TransportDirection": "InfluxLumenToMucosaIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Periportal",
-              "MembraneLocation": "Basolateral",
-              "Value": 1.0
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Periportal",
+              "TransportDirection": "ExcretionLiver",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Pericentral",
-              "MembraneLocation": "Basolateral",
-              "Value": 1.0
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Interstitial"
+            },
+            {
+              "Name": "Pericentral",
+              "TransportDirection": "ExcretionLiver",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Lung",
-              "MembraneLocation": "Basolateral",
-              "Value": 4.0079365079E-05
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
             },
             {
               "Name": "Muscle",
-              "MembraneLocation": "Basolateral",
-              "Value": 0.00064682539683
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Pancreas",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Skin",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "Spleen",
+              "TransportDirection": "InfluxInterstitialToIntracellular",
+              "CompartmentName": "Intracellular"
+            },
+            {
+              "Name": "BloodCells",
+              "TransportDirection": "InfluxPlasmaToBloodCells"
+            },
+            {
+              "Name": "VascularEndothelium",
+              "TransportDirection": "InfluxPlasmaToInterstitial"
             }
           ]
         },
         {
           "Name": "ATP1A2",
           "Type": "OtherProtein",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "ExtracellularMembrane",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "Bone",
-              "Value": 0.0062154033171
-            },
-            {
-              "Name": "Brain",
-              "Value": 1.0
-            },
-            {
-              "Name": "Gonads",
-              "Value": 0.0508741242
-            },
-            {
-              "Name": "Heart",
-              "Value": 0.3179118843
-            },
-            {
-              "Name": "Kidney",
-              "Value": 0.0158938619
-            },
-            {
-              "Name": "Periportal",
-              "Value": 0.0223784807
-            },
-            {
-              "Name": "Pericentral",
-              "Value": 0.0223784807
-            },
-            {
-              "Name": "Lung",
-              "Value": 0.0272345453
-            },
-            {
-              "Name": "Muscle",
-              "Value": 0.7034193524
-            },
-            {
-              "Name": "Pancreas",
-              "Value": 0.0073903254795
-            },
-            {
-              "Name": "Skin",
-              "Value": 0.0389467988
-            },
-            {
-              "Name": "Spleen",
-              "Value": 0.0103243118
-            },
-            {
-              "Name": "Stomach",
-              "Value": 0.0309435884
-            },
-            {
-              "Name": "SmallIntestine",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "LargeIntestine",
-              "Value": 0.0786998764
-            },
-            {
-              "Name": "Duodenum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "UpperJejunum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "LowerJejunum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "UpperIleum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "LowerIleum",
-              "Value": 0.0501579923
-            },
-            {
-              "Name": "ColonAscendens",
-              "Value": 0.0786998764
-            },
-            {
-              "Name": "ColonTransversum",
-              "Value": 0.0786998764
-            },
-            {
-              "Name": "ColonDescendens",
-              "Value": 0.0786998764
-            },
-            {
-              "Name": "ColonSigmoid",
-              "Value": 0.0786998764
-            }
-          ],
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 0.47661714,
-              "Unit": "µmol/l",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            }
-          ]
+          "Localization": "Interstitial, BloodCellsMembrane, VascMembranePlasmaSide"
         },
         {
           "Name": "UGT1A4",
           "Type": "Enzyme",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "Intracellular",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "Periportal",
-              "Value": 1.0
-            },
-            {
-              "Name": "Pericentral",
-              "Value": 1.0
-            }
-          ],
+          "Localization": "Intracellular, BloodCellsIntracellular, VascEndosome",
           "Ontogeny": {
             "Name": "UGT1A4"
-          },
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 2.32,
-              "Unit": "µmol/l",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            }
-          ]
+          }
         },
         {
           "Name": "GABRG2",
           "Type": "OtherProtein",
-          "MembraneLocation": "Apical",
-          "TissueLocation": "ExtracellularMembrane",
-          "IntracellularVascularEndoLocation": "Endosomal",
-          "Expression": [
-            {
-              "Name": "Brain",
-              "Value": 1.0
-            }
-          ],
-          "Parameters": [
-            {
-              "Name": "Reference concentration",
-              "Value": 1.0877710492,
-              "Unit": "µmol/l",
-              "ValueOrigin": {
-                "Source": "Unknown"
-              }
-            }
-          ]
+          "Localization": "Interstitial, BloodCellsMembrane, VascMembranePlasmaSide"
         }
       ]
     }
@@ -1791,7 +2705,7 @@
             },
             {
               "Name": "kcat",
-              "Value": 7.796,
+              "Value": 5.21004653,
               "Unit": "1/min",
               "ValueOrigin": {
                 "Source": "Publication",
@@ -1861,15 +2775,15 @@
               "Unit": "µmol/l",
               "ValueOrigin": {
                 "Source": "Publication",
-                "Description": "Templeton 2011 (weighted mean for FHH)"
+                "Description": "Dose-Response-Calibration"
               }
             },
             {
               "Name": "Emax",
               "Value": 9.0,
               "ValueOrigin": {
-                "Source": "Publication",
-                "Description": "Templeton 2011 (weighted mean for FHH)"
+                "Source": "ParameterIdentification",
+                "Description": "Dose-Response-Calibration"
               }
             }
           ]
@@ -2214,6 +3128,11 @@
           ],
           "Parameters": [
             {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
+            {
               "Name": "NumberOfRepetitions",
               "Value": 7.0,
               "ValueOrigin": {
@@ -2331,6 +3250,11 @@
           ],
           "Parameters": [
             {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
+            {
               "Name": "NumberOfRepetitions",
               "Value": 7.0,
               "ValueOrigin": {
@@ -2382,6 +3306,11 @@
           ],
           "Parameters": [
             {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
+            {
               "Name": "NumberOfRepetitions",
               "Value": 7.0,
               "ValueOrigin": {
@@ -2400,6 +3329,258 @@
         }
       ],
       "TimeUnit": "h"
+    },
+    {
+      "Name": "po 600 mg MD OD (16 days)",
+      "DosingInterval": "Single",
+      "Schemas": [
+        {
+          "Name": "Schema 1",
+          "SchemaItems": [
+            {
+              "Name": "Schema Item 1",
+              "ApplicationType": "Oral",
+              "FormulationKey": "Formulation",
+              "Parameters": [
+                {
+                  "Name": "Start time",
+                  "Value": 0.0,
+                  "Unit": "h"
+                },
+                {
+                  "Name": "InputDose",
+                  "Value": 600.0,
+                  "Unit": "mg"
+                },
+                {
+                  "Name": "Volume of water/body weight",
+                  "Value": 3.5,
+                  "Unit": "ml/kg"
+                }
+              ]
+            }
+          ],
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "NumberOfRepetitions",
+              "Value": 16.0,
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "TimeBetweenRepetitions",
+              "Value": 24.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "TimeUnit": "h"
+    },
+    {
+      "Name": "Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days",
+      "DosingInterval": "Single",
+      "Schemas": [
+        {
+          "Name": "Schema 1",
+          "SchemaItems": [
+            {
+              "Name": "Schema Item 1",
+              "ApplicationType": "Oral",
+              "FormulationKey": "Formulation",
+              "Parameters": [
+                {
+                  "Name": "Start time",
+                  "Value": 0.0,
+                  "Unit": "h"
+                },
+                {
+                  "Name": "InputDose",
+                  "Value": 600.0,
+                  "Unit": "mg"
+                },
+                {
+                  "Name": "Volume of water/body weight",
+                  "Value": 3.5,
+                  "Unit": "ml/kg"
+                }
+              ]
+            }
+          ],
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "NumberOfRepetitions",
+              "Value": 7.0,
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "TimeBetweenRepetitions",
+              "Value": 24.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "Schema 2",
+          "SchemaItems": [
+            {
+              "Name": "Schema Item 1",
+              "ApplicationType": "Oral",
+              "FormulationKey": "Formulation",
+              "Parameters": [
+                {
+                  "Name": "Start time",
+                  "Value": 0.0,
+                  "Unit": "h"
+                },
+                {
+                  "Name": "InputDose",
+                  "Value": 600.0,
+                  "Unit": "mg"
+                },
+                {
+                  "Name": "Volume of water/body weight",
+                  "Value": 3.5,
+                  "Unit": "ml/kg"
+                }
+              ]
+            }
+          ],
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 192.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "NumberOfRepetitions",
+              "Value": 3.0,
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "TimeBetweenRepetitions",
+              "Value": 24.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        },
+        {
+          "Name": "Schema 3",
+          "SchemaItems": [
+            {
+              "Name": "Schema Item 1",
+              "ApplicationType": "Oral",
+              "FormulationKey": "Formulation",
+              "Parameters": [
+                {
+                  "Name": "Start time",
+                  "Value": 0.0,
+                  "Unit": "h"
+                },
+                {
+                  "Name": "InputDose",
+                  "Value": 600.0,
+                  "Unit": "mg"
+                },
+                {
+                  "Name": "Volume of water/body weight",
+                  "Value": 3.5,
+                  "Unit": "ml/kg"
+                }
+              ]
+            }
+          ],
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 180.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "NumberOfRepetitions",
+              "Value": 1.0
+            },
+            {
+              "Name": "TimeBetweenRepetitions",
+              "Value": 0.0,
+              "Unit": "h"
+            }
+          ]
+        }
+      ],
+      "TimeUnit": "h"
+    }
+  ],
+  "ObserverSets": [
+    {
+      "Name": "Fold-change in concentration",
+      "Observers": [
+        {
+          "Name": "Fold-change in concentration",
+          "Dimension": "Dimensionless",
+          "ContainerCriteria": [
+            {
+              "Tag": "Gallbladder",
+              "Type": "Not"
+            },
+            {
+              "Tag": "LumenSegment",
+              "Type": "Not"
+            }
+          ],
+          "Formula": {
+            "Name": "Fold-change in concentration",
+            "Formula": "Start_amount>0 ? Amount/Start_amount : 0",
+            "References": [
+              {
+                "Alias": "Amount",
+                "Dimension": "Amount",
+                "Path": "..|..|MOLECULE"
+              },
+              {
+                "Alias": "Start_amount",
+                "Dimension": "Concentration (molar)",
+                "Path": "..|..|MOLECULE|Start amount"
+              }
+            ],
+            "Dimension": "Dimensionless"
+          },
+          "MoleculeList": {
+            "ForAll": true
+          },
+          "Type": "Amount"
+        }
+      ]
     }
   ],
   "Simulations": [
@@ -2520,7 +3701,8 @@
               "MoleculeName": "OATP1B1"
             },
             {
-              "Name": "Glomerular Filtration-GFR"
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
             }
           ],
           "Protocol": {
@@ -2728,7 +3910,8 @@
               "MoleculeName": "OATP1B1"
             },
             {
-              "Name": "Glomerular Filtration-GFR"
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
             }
           ],
           "Protocol": {
@@ -2916,7 +4099,8 @@
               "MoleculeName": "OATP1B1"
             },
             {
-              "Name": "Glomerular Filtration-GFR"
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
             }
           ],
           "Protocol": {
@@ -3175,7 +4359,8 @@
               "MoleculeName": "OATP1B1"
             },
             {
-              "Name": "Glomerular Filtration-GFR"
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
             }
           ],
           "Protocol": {
@@ -3432,7 +4617,8 @@
               "MoleculeName": "OATP1B1"
             },
             {
-              "Name": "Glomerular Filtration-GFR"
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
             }
           ],
           "Protocol": {
@@ -3621,7 +4807,8 @@
               "MoleculeName": "OATP1B1"
             },
             {
-              "Name": "Glomerular Filtration-GFR"
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
             }
           ],
           "Protocol": {
@@ -3922,7 +5109,8 @@
               "MoleculeName": "OATP1B1"
             },
             {
-              "Name": "Glomerular Filtration-GFR"
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
             }
           ],
           "Protocol": {
@@ -4188,7 +5376,8 @@
               "MoleculeName": "OATP1B1"
             },
             {
-              "Name": "Glomerular Filtration-GFR"
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
             }
           ],
           "Protocol": {
@@ -4408,7 +5597,8 @@
               "MoleculeName": "OATP1B1"
             },
             {
-              "Name": "Glomerular Filtration-GFR"
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
             }
           ],
           "Protocol": {
@@ -4542,7 +5732,9 @@
         "Blume 1989 - 600 mg REFERENZ - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)",
         "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Serum - agg. (n=6)",
         "Furesz 1970 - 600 mg - Rifampicin - PO - 600 mg - Serum - agg. (n=12)",
-        "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Rifadine Tab - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)"
+        "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Rifadine Tab - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)",
+        "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Urine - agg. (n=6)",
+        "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Tab (Eon) - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)"
       ],
       "Solver": {},
       "OutputSchema": [
@@ -4596,7 +5788,8 @@
         }
       ],
       "OutputSelections": [
-        "Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)"
+        "Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+        "Organism|Kidney|Urine|Rifampicin"
       ],
       "Individual": "European (P-gp modified, CYP3A4 36 h)",
       "Compounds": [
@@ -4626,7 +5819,8 @@
               "MoleculeName": "OATP1B1"
             },
             {
-              "Name": "Glomerular Filtration-GFR"
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
             }
           ],
           "Protocol": {
@@ -4734,10 +5928,70 @@
                 "LineStyle": "None",
                 "Symbol": "Circle"
               }
+            },
+            {
+              "Name": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Tab (Eon) - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+              "X": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Tab (Eon) - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)|Time",
+              "Y": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Tab (Eon) - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+              "CurveOptions": {
+                "Color": "#800080",
+                "LegendIndex": 7,
+                "LineStyle": "None",
+                "Symbol": "Circle"
+              }
             }
           ],
           "Name": "Rifampicin po 600 mg",
-          "OriginText": "Rifampicin-Model\nRifampicin po 600 mg\n2020-02-10 11:59"
+          "OriginText": "Rifampicin\nRifampicin po 600 mg\n2021-05-04 19:29"
+        },
+        {
+          "Axes": [
+            {
+              "Unit": "h",
+              "Dimension": "Time",
+              "Type": "X",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "None",
+              "Scaling": "Linear",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "mg",
+              "Dimension": "Amount",
+              "Type": "Y",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Solid",
+              "Scaling": "Linear",
+              "NumberMode": "Normal"
+            }
+          ],
+          "Curves": [
+            {
+              "Name": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Urine - agg. (n=6)-Rifampicin-Kidney-Urine-ArithmeticMean",
+              "X": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Urine - agg. (n=6)|Time",
+              "Y": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Urine - agg. (n=6)|ObservedData|Kidney|Urine|Rifampicin|ArithmeticMean",
+              "CurveOptions": {
+                "Color": "#FF0000",
+                "LegendIndex": 2,
+                "LineStyle": "None",
+                "Symbol": "Circle"
+              }
+            },
+            {
+              "Name": "Rifampicin-Kidney-Urine-Amount in container",
+              "X": "Time",
+              "Y": "Rifampicin po 600 mg|Organism|Kidney|Urine|Rifampicin",
+              "CurveOptions": {
+                "LegendIndex": 1
+              }
+            }
+          ],
+          "Name": "Rifampicin po 600 mg",
+          "OriginText": "Rifampicin\nRifampicin po 600 mg\n2021-05-04 19:29"
         }
       ],
       "Interactions": [
@@ -4898,7 +6152,8 @@
               "MoleculeName": "OATP1B1"
             },
             {
-              "Name": "Glomerular Filtration-GFR"
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
             }
           ],
           "Protocol": {
@@ -5138,6 +6393,4013 @@
           "Name": "OATP1B1-Dixit 2007",
           "MoleculeName": "OATP1B1",
           "CompoundName": "Rifampicin"
+        }
+      ]
+    },
+    {
+      "Name": "Rifampicin po 600 mg MD OD (16 days)",
+      "Model": "4Comp",
+      "ObservedData": [
+        "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)",
+        "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)",
+        "Westphal 2000 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)"
+      ],
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 16.0,
+              "Unit": "day(s)"
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h"
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_10|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_11|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_12|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_13|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_14|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_15|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_16|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_2|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_3|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_4|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_5|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_6|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_7|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_8|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|po 600 mg MD OD (16 days)|Oral solution|Application_9|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+        "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Fold-change in concentration",
+        "Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Fold-change in concentration",
+        "Organism|Liver|Periportal|Intracellular|CYP3A4|Fold-change in concentration",
+        "Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Fold-change in concentration"
+      ],
+      "Individual": "European (P-gp modified, CYP3A4 36 h)",
+      "Compounds": [
+        {
+          "Name": "Rifampicin",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Optimized",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "Name": "AADAC-Nakajima 2011",
+              "MoleculeName": "AADAC"
+            },
+            {
+              "MoleculeName": "UGT1A4"
+            },
+            {
+              "Name": "P-gp-Collett 2004",
+              "MoleculeName": "P-gp"
+            },
+            {
+              "Name": "OATP1B1-Tirona 2003",
+              "MoleculeName": "OATP1B1"
+            },
+            {
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
+            }
+          ],
+          "Protocol": {
+            "Name": "po 600 mg MD OD (16 days)",
+            "Formulations": [
+              {
+                "Name": "Oral solution",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "ObserverSets": [
+        {
+          "Name": "Fold-change in concentration"
+        }
+      ],
+      "HasResults": true,
+      "IndividualAnalyses": [
+        {
+          "Axes": [
+            {
+              "Unit": "h",
+              "Dimension": "Time",
+              "Type": "X",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "None",
+              "Scaling": "Linear",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "µmol/l",
+              "Dimension": "Concentration (molar)",
+              "Type": "Y",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Solid",
+              "Scaling": "Log",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "",
+              "Dimension": "Dimensionless",
+              "Type": "Y2",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Dash",
+              "Scaling": "Linear",
+              "NumberMode": "Normal"
+            }
+          ],
+          "Curves": [
+            {
+              "Name": "CYP3A4-Liver Periportal-Intracellular-Fold-change in concentration",
+              "X": "Time",
+              "Y": "Rifampicin po 600 mg MD OD (16 days)|Organism|Liver|Periportal|Intracellular|CYP3A4|Fold-change in concentration",
+              "CurveOptions": {
+                "yAxisType": "Y2",
+                "Color": "#0000FF",
+                "LegendIndex": 2,
+                "LineStyle": "Dash"
+              }
+            },
+            {
+              "Name": "Intracellular - agg. (n=8)-ObservedData-Duodenum-Intracellular-CYP3A4-ArithmeticMean",
+              "X": "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|Time",
+              "Y": "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|ObservedData|Duodenum|Intracellular|CYP3A4|ArithmeticMean",
+              "CurveOptions": {
+                "yAxisType": "Y2",
+                "Color": "#FF00FF",
+                "LegendIndex": 7,
+                "LineStyle": "None",
+                "Symbol": "Circle"
+              }
+            },
+            {
+              "Name": "Intracellular - agg. (n=8)-ObservedData-Duodenum-Intracellular-P-gp-ArithmeticMean",
+              "X": "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|Time",
+              "Y": "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|ObservedData|Duodenum|Intracellular|P-gp|ArithmeticMean",
+              "CurveOptions": {
+                "yAxisType": "Y2",
+                "Color": "#FF0000",
+                "LegendIndex": 8,
+                "LineStyle": "None",
+                "Symbol": "Circle"
+              }
+            },
+            {
+              "Name": "Intracellular - agg. (n=8)-ObservedData-Duodenum-Intracellular-P-gp-ArithmeticMean",
+              "X": "Westphal 2000 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|Time",
+              "Y": "Westphal 2000 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|ObservedData|Duodenum|Intracellular|P-gp|ArithmeticMean",
+              "CurveOptions": {
+                "yAxisType": "Y2",
+                "Color": "#FF0000",
+                "LegendIndex": 9,
+                "LineStyle": "None",
+                "Symbol": "Circle"
+              }
+            },
+            {
+              "Name": "CYP3A4-Upper Jejunum-Intracellular-Fold-change in concentration",
+              "X": "Time",
+              "Y": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|CYP3A4|Fold-change in concentration",
+              "CurveOptions": {
+                "yAxisType": "Y2",
+                "Color": "#008000",
+                "LegendIndex": 5,
+                "LineStyle": "Dash"
+              }
+            },
+            {
+              "Name": "CYP3A4-Duodenum-Intracellular-Fold-change in concentration",
+              "X": "Time",
+              "Y": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Fold-change in concentration",
+              "CurveOptions": {
+                "yAxisType": "Y2",
+                "Color": "#FF00FF",
+                "LegendIndex": 4,
+                "LineStyle": "Dash"
+              }
+            },
+            {
+              "Name": "P-gp-Duodenum-Intracellular-Fold-change in concentration",
+              "X": "Time",
+              "Y": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Fold-change in concentration",
+              "CurveOptions": {
+                "yAxisType": "Y2",
+                "Color": "#FF0000",
+                "LegendIndex": 6,
+                "LineStyle": "Dash"
+              }
+            },
+            {
+              "Name": "Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+              "X": "Time",
+              "Y": "Rifampicin po 600 mg MD OD (16 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+              "CurveOptions": {
+                "LegendIndex": 1
+              }
+            }
+          ],
+          "Name": "Rifampicin po 600 mg MD OD (7 days)",
+          "Settings": {
+            "SideMarginsEnabled": true,
+            "LegendPosition": "BottomInside",
+            "BackColor": "#FFFFFF",
+            "DiagramBackColor": "#FFFFFF"
+          },
+          "OriginText": "Rifampicin\nRifampicin po 600 mg MD OD (16 days)\n2021-05-04 12:53"
+        }
+      ],
+      "Interactions": [
+        {
+          "Name": "CYP3A4-Kajosaari 2005",
+          "MoleculeName": "CYP3A4",
+          "CompoundName": "Rifampicin"
+        },
+        {
+          "Name": "P-gp-Reitman 2011",
+          "MoleculeName": "P-gp",
+          "CompoundName": "Rifampicin"
+        },
+        {
+          "Name": "OATP1B1-Hirano 2006",
+          "MoleculeName": "OATP1B1",
+          "CompoundName": "Rifampicin"
+        },
+        {
+          "Name": "CYP3A4-Templeton 2011",
+          "MoleculeName": "CYP3A4",
+          "CompoundName": "Rifampicin"
+        },
+        {
+          "Name": "AADAC-Assumed",
+          "MoleculeName": "AADAC",
+          "CompoundName": "Rifampicin"
+        },
+        {
+          "Name": "P-gp-Greiner 1999",
+          "MoleculeName": "P-gp",
+          "CompoundName": "Rifampicin"
+        },
+        {
+          "Name": "OATP1B1-Dixit 2007",
+          "MoleculeName": "OATP1B1",
+          "CompoundName": "Rifampicin"
+        }
+      ]
+    },
+    {
+      "Name": "Rifampicin po 600 mg Chattopadhyay 2018",
+      "Model": "4Comp",
+      "ObservedData": [
+        "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)"
+      ],
+      "Solver": {},
+      "OutputSchema": [
+        {
+          "Parameters": [
+            {
+              "Name": "Start time",
+              "Value": 0.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "End time",
+              "Value": 264.0,
+              "Unit": "h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            },
+            {
+              "Name": "Resolution",
+              "Value": 20.0,
+              "Unit": "pts/h",
+              "ValueOrigin": {
+                "Source": "Unknown"
+              }
+            }
+          ]
+        }
+      ],
+      "Parameters": [
+        {
+          "Path": "Applications|Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days|Oral solution|Application_1|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days|Oral solution|Application_10|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days|Oral solution|Application_11|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days|Oral solution|Application_2|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days|Oral solution|Application_3|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days|Oral solution|Application_4|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days|Oral solution|Application_5|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days|Oral solution|Application_6|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days|Oral solution|Application_7|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days|Oral solution|Application_8|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        },
+        {
+          "Path": "Applications|Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days|Oral solution|Application_9|ProtocolSchemaItem|Volume of water/body weight",
+          "Value": 3.5,
+          "Unit": "ml/kg"
+        }
+      ],
+      "OutputSelections": [
+        "Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+        "Organism|Kidney|Urine|Rifampicin"
+      ],
+      "Individual": "European (P-gp modified, CYP3A4 36 h)",
+      "Compounds": [
+        {
+          "Name": "Rifampicin",
+          "CalculationMethods": [
+            "Cellular partition coefficient method - Rodgers and Rowland",
+            "Cellular permeability - PK-Sim Standard"
+          ],
+          "Alternatives": [
+            {
+              "AlternativeName": "Optimized",
+              "GroupName": "COMPOUND_INTESTINAL_PERMEABILITY"
+            }
+          ],
+          "Processes": [
+            {
+              "MoleculeName": "CYP3A4"
+            },
+            {
+              "Name": "AADAC-Nakajima 2011",
+              "MoleculeName": "AADAC"
+            },
+            {
+              "MoleculeName": "UGT1A4"
+            },
+            {
+              "Name": "P-gp-Collett 2004",
+              "MoleculeName": "P-gp"
+            },
+            {
+              "Name": "OATP1B1-Tirona 2003",
+              "MoleculeName": "OATP1B1"
+            },
+            {
+              "Name": "Glomerular Filtration-GFR",
+              "SystemicProcessType": "GFR"
+            }
+          ],
+          "Protocol": {
+            "Name": "Chattopadhyay 2018 - Rifampicin - 600 mg MD 11 days",
+            "Formulations": [
+              {
+                "Name": "Oral solution",
+                "Key": "Formulation"
+              }
+            ]
+          }
+        }
+      ],
+      "HasResults": true,
+      "IndividualAnalyses": [
+        {
+          "Axes": [
+            {
+              "Unit": "h",
+              "Dimension": "Time",
+              "Type": "X",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "None",
+              "Scaling": "Linear",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "µmol/l",
+              "Dimension": "Concentration (molar)",
+              "Type": "Y",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Solid",
+              "Scaling": "Log",
+              "NumberMode": "Normal"
+            },
+            {
+              "Unit": "",
+              "Dimension": "Dimensionless",
+              "Type": "Y2",
+              "GridLines": false,
+              "Visible": true,
+              "DefaultColor": "#FFFFFF",
+              "DefaultLineStyle": "Dash",
+              "Scaling": "Log",
+              "NumberMode": "Normal"
+            }
+          ],
+          "Curves": [
+            {
+              "Name": "Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+              "X": "Time",
+              "Y": "Rifampicin po 600 mg Chattopadhyay 2018|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+              "CurveOptions": {
+                "Color": "#FF0000",
+                "LegendIndex": 1
+              }
+            },
+            {
+              "Name": "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)-Rifampicin-Peripheral Venous Blood-Plasma-GeometricMean",
+              "X": "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)|Time",
+              "Y": "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|GeometricMean",
+              "CurveOptions": {
+                "Color": "#FF0000",
+                "LegendIndex": 2,
+                "LineStyle": "None",
+                "Symbol": "Circle"
+              }
+            }
+          ],
+          "Name": "Time Profile Analysis",
+          "OriginText": "Rifampicin\nRifampicin po 600 mg Chattopadhyay 2018\n2021-05-05 10:48"
+        }
+      ],
+      "Interactions": [
+        {
+          "Name": "CYP3A4-Kajosaari 2005",
+          "MoleculeName": "CYP3A4",
+          "CompoundName": "Rifampicin"
+        },
+        {
+          "Name": "P-gp-Reitman 2011",
+          "MoleculeName": "P-gp",
+          "CompoundName": "Rifampicin"
+        },
+        {
+          "Name": "OATP1B1-Hirano 2006",
+          "MoleculeName": "OATP1B1",
+          "CompoundName": "Rifampicin"
+        },
+        {
+          "Name": "CYP3A4-Templeton 2011",
+          "MoleculeName": "CYP3A4",
+          "CompoundName": "Rifampicin"
+        },
+        {
+          "Name": "AADAC-Assumed",
+          "MoleculeName": "AADAC",
+          "CompoundName": "Rifampicin"
+        },
+        {
+          "Name": "P-gp-Greiner 1999",
+          "MoleculeName": "P-gp",
+          "CompoundName": "Rifampicin"
+        },
+        {
+          "Name": "OATP1B1-Dixit 2007",
+          "MoleculeName": "OATP1B1",
+          "CompoundName": "Rifampicin"
+        }
+      ]
+    }
+  ],
+  "ParameterIdentifications": [
+    {
+      "Name": "PI Hanke et al. 2018",
+      "Simulations": [
+        "Rifampicin po 300 mg",
+        "Rifampicin po 450 mg",
+        "Rifampicin po 450 mg MD OD (7 days)",
+        "Rifampicin po 600 mg",
+        "Rifampicin po 600 mg MD OD (7 days)",
+        "Rifampicin po 600 mg MD OD (16 days)",
+        "Rifampicin iv 600 mg (3 h) MD OD (7 days)",
+        "Rifampicin iv 600 mg (3 h)",
+        "Rifampicin iv 600 mg (0.5 h)",
+        "Rifampicin iv 450 mg (3 h)",
+        "Rifampicin iv 300 mg (3 h)",
+        "Rifampicin iv 300 mg (0.5 h)"
+      ],
+      "Configuration": {
+        "LLOQMode": "SimulationOutputAsObservedDataLLOQ",
+        "RemoveLLOQMode": "Never",
+        "CalculateJacobian": false,
+        "Algorithm": {
+          "Name": "Levenberg - Marquardt (MPFit)",
+          "Properties": [
+            {
+              "Name": "ftol",
+              "Value": 0.001
+            },
+            {
+              "Name": "xtol",
+              "Value": 1E-06
+            },
+            {
+              "Name": "gtol",
+              "Value": 1E-10
+            },
+            {
+              "Name": "stepfactor",
+              "Value": 100.0
+            },
+            {
+              "Name": "maxiter",
+              "Value": 200.0
+            },
+            {
+              "Name": "maxfev",
+              "Value": 0.0
+            },
+            {
+              "Name": "epsfcn",
+              "Value": 1E-09
+            }
+          ]
+        }
+      },
+      "OutputMappings": [
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin po 300 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Chouchane 1995 - Rifampicin Generic - Rifampicin - PO - 300 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 300 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Chouchane 1995 - Rimactan - Rifampicin - PO - 300 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 300 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Furesz 1970 - 300 mg - Rifampicin - PO - 300 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.75,
+          "Path": "Rifampicin po 450 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Blume 1989 - 450 mg REFERENZ - Rifampicin - PO - 450 mg - Plasma - agg. (n=8)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 450 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 450 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Furesz 1970 - 450 mg - Rifampicin - PO - 450 mg - Serum - agg. (n=13)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin po 450 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1972a - day 7 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.75,
+          "Path": "Rifampicin po 450 mg MD OD (7 days)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Urine - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Peloquin 1997 - 600 mg - Rifampicin - PO - 600 mg - Plasma - agg. (n=24)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Rifadine Tab - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Blume 1989 - 600 mg REFERENZ - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Serum - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Furesz 1970 - 600 mg - Rifampicin - PO - 600 mg - Serum - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 10.0,
+          "Path": "Rifampicin po 600 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Baneyx 2014 - Day 4 - 600 mg po MD - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 10.0,
+          "Path": "Rifampicin po 600 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Baneyx 2014 - Day 7 - 600 mg po MD - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Serum - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 5.0,
+          "Path": "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1977 - mean 600 mg MD - Rifampicin - IV - 600 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 600 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Urine - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin iv 600 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Acocella 1977 - mean 600 mg MD - Rifampicin - IV - 600 mg - Urine - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 600 mg (0.5 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "sanofi-aventis U.S. LLC. 2013 - 600 mg - Rifampicin - IV - 600 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 450 mg (3 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Nitti 1977 - 450 mg - Rifampicin - IV - 450 mg - Serum - agg. (n=3)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 450 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Nitti 1977 - 450 mg - Rifampicin - IV - 450 mg - Urine - agg. (n=3)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 300 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Nitti 1977 - 300 mg - Rifampicin - IV - 300 mg - Urine - agg. (n=2)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 300 mg (3 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Nitti 1977 - 300 mg - Rifampicin - IV - 300 mg - Serum - agg. (n=2)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 300 mg (0.5 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "sanofi-aventis U.S. LLC. 2013 - 300 mg - Rifampicin - IV - 300 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 8.0,
+          "Path": "Rifampicin po 600 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Peloquin 1997 - 600 mg - Rifampicin - PO - 600 mg - Plasma - agg. (n=24)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 15.0,
+          "Path": "Rifampicin iv 600 mg (3 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Serum - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.75,
+          "Path": "Rifampicin po 450 mg MD OD (7 days)|Organism|Gallbladder|Rifampicin",
+          "ObservedData": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Bile - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin po 450 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Urine - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 5.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Tab (Eon) - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Fold-change in concentration",
+          "ObservedData": "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Fold-change in concentration",
+          "ObservedData": "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Fold-change in concentration",
+          "ObservedData": "Westphal 2000 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)"
+        }
+      ],
+      "IdentificationParameters": [
+        {
+          "Name": "Lipophilicity",
+          "Scaling": "Linear",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Lipophilicity",
+            "Rifampicin po 450 mg|Rifampicin|Lipophilicity",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Lipophilicity",
+            "Rifampicin po 600 mg|Rifampicin|Lipophilicity",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Lipophilicity",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Lipophilicity"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 2.5,
+              "Unit": "Log Units"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 2.0,
+              "Unit": "Log Units"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 3.5,
+              "Unit": "Log Units"
+            }
+          ]
+        },
+        {
+          "Name": "P-gp kcat",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 450 mg|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 600 mg|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|P-gp-Collett 2004|kcat"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.6088,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.01,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 500.0,
+              "Unit": "1/min"
+            }
+          ]
+        },
+        {
+          "Name": "OATP kcat",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 450 mg|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 600 mg|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|OATP1B1-Tirona 2003|kcat"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 7.796,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.01,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 500.0,
+              "Unit": "1/min"
+            }
+          ]
+        },
+        {
+          "Name": "Esterase kcat",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 450 mg|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 600 mg|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin-AADAC-Nakajima 2011|kcat"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 9.865,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.01,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 500.0,
+              "Unit": "1/min"
+            }
+          ]
+        },
+        {
+          "Name": "P int",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 450 mg|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 600 mg|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Specific intestinal permeability (transcellular)"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 1.24E-05,
+              "Unit": "cm/min"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 3.48E-07,
+              "Unit": "cm/min"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 0.00348,
+              "Unit": "cm/min"
+            }
+          ]
+        },
+        {
+          "Name": "Esterase t1/2 (liver)",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|AADAC|t1/2 (liver)",
+            "Rifampicin po 450 mg|AADAC|t1/2 (liver)",
+            "Rifampicin po 450 mg MD OD (7 days)|AADAC|t1/2 (liver)",
+            "Rifampicin po 600 mg|AADAC|t1/2 (liver)",
+            "Rifampicin po 600 mg MD OD (7 days)|AADAC|t1/2 (liver)",
+            "Rifampicin po 600 mg MD OD (16 days)|AADAC|t1/2 (liver)",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|AADAC|t1/2 (liver)",
+            "Rifampicin iv 600 mg (3 h)|AADAC|t1/2 (liver)",
+            "Rifampicin iv 600 mg (0.5 h)|AADAC|t1/2 (liver)",
+            "Rifampicin iv 450 mg (3 h)|AADAC|t1/2 (liver)",
+            "Rifampicin iv 300 mg (3 h)|AADAC|t1/2 (liver)",
+            "Rifampicin iv 300 mg (0.5 h)|AADAC|t1/2 (liver)"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 36.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 24.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 150.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "P-gp t1/2 (liver)",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|P-gp|t1/2 (liver)",
+            "Rifampicin po 450 mg|P-gp|t1/2 (liver)",
+            "Rifampicin po 450 mg MD OD (7 days)|P-gp|t1/2 (liver)",
+            "Rifampicin po 600 mg|P-gp|t1/2 (liver)",
+            "Rifampicin po 600 mg MD OD (7 days)|P-gp|t1/2 (liver)",
+            "Rifampicin po 600 mg MD OD (16 days)|P-gp|t1/2 (liver)",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|P-gp|t1/2 (liver)",
+            "Rifampicin iv 600 mg (3 h)|P-gp|t1/2 (liver)",
+            "Rifampicin iv 600 mg (0.5 h)|P-gp|t1/2 (liver)",
+            "Rifampicin iv 450 mg (3 h)|P-gp|t1/2 (liver)",
+            "Rifampicin iv 300 mg (3 h)|P-gp|t1/2 (liver)",
+            "Rifampicin iv 300 mg (0.5 h)|P-gp|t1/2 (liver)"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 36.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 24.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 150.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "OATP t1/2 (liver)",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|OATP1B1|t1/2 (liver)",
+            "Rifampicin po 450 mg|OATP1B1|t1/2 (liver)",
+            "Rifampicin po 450 mg MD OD (7 days)|OATP1B1|t1/2 (liver)",
+            "Rifampicin po 600 mg|OATP1B1|t1/2 (liver)",
+            "Rifampicin po 600 mg MD OD (7 days)|OATP1B1|t1/2 (liver)",
+            "Rifampicin po 600 mg MD OD (16 days)|OATP1B1|t1/2 (liver)",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|OATP1B1|t1/2 (liver)",
+            "Rifampicin iv 600 mg (3 h)|OATP1B1|t1/2 (liver)",
+            "Rifampicin iv 600 mg (0.5 h)|OATP1B1|t1/2 (liver)",
+            "Rifampicin iv 450 mg (3 h)|OATP1B1|t1/2 (liver)",
+            "Rifampicin iv 300 mg (3 h)|OATP1B1|t1/2 (liver)",
+            "Rifampicin iv 300 mg (0.5 h)|OATP1B1|t1/2 (liver)"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 36.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 24.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 150.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "P-gp Emax",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 450 mg|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 600 mg|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|P-gp-Greiner 1999|Emax"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 2.5
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.01
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 25.0
+            }
+          ]
+        },
+        {
+          "Name": "P-gp EC50",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 450 mg|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 600 mg|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|P-gp-Greiner 1999|EC50"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.34,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.0001,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 1000.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "Esterase Emax",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 450 mg|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 600 mg|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|AADAC-Assumed|Emax"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.985
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.1
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 100.0
+            }
+          ]
+        },
+        {
+          "Name": "Esterase EC50",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 450 mg|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 600 mg|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|AADAC-Assumed|EC50"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.34,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.0001,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 1000.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "OATP Emax",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 450 mg|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 600 mg|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|OATP1B1-Dixit 2007|Emax"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.383
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.1
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 100.0
+            }
+          ]
+        },
+        {
+          "Name": "OATP EC50",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 450 mg|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 600 mg|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|OATP1B1-Dixit 2007|EC50"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.34,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.0001,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 1000.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "Solubility at reference pH",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 450 mg|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 600 mg|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Solubility at reference pH"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 2800.0,
+              "Unit": "mg/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 45.0,
+              "Unit": "mg/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 4500.0,
+              "Unit": "mg/l"
+            }
+          ]
+        },
+        {
+          "Name": "Fraction unbound (plasma, reference value)",
+          "Scaling": "Linear",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin po 450 mg|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin po 600 mg|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Fraction unbound (plasma, reference value)"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 17.0,
+              "Unit": "%"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 1.1,
+              "Unit": "%"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 100.0,
+              "Unit": "%"
+            }
+          ]
+        },
+        {
+          "Name": "Reference pH",
+          "Scaling": "Linear",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Reference pH",
+            "Rifampicin po 450 mg|Rifampicin|Reference pH",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Reference pH",
+            "Rifampicin po 600 mg|Rifampicin|Reference pH",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Reference pH",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Reference pH",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Reference pH",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Reference pH",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Reference pH",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Reference pH",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Reference pH",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Reference pH"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 7.5
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.0
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 14.0
+            }
+          ]
+        },
+        {
+          "Name": "Ref conc P-gp",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|P-gp|Reference concentration",
+            "Rifampicin po 450 mg|P-gp|Reference concentration",
+            "Rifampicin po 450 mg MD OD (7 days)|P-gp|Reference concentration",
+            "Rifampicin po 600 mg|P-gp|Reference concentration",
+            "Rifampicin po 600 mg MD OD (7 days)|P-gp|Reference concentration",
+            "Rifampicin po 600 mg MD OD (16 days)|P-gp|Reference concentration",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|P-gp|Reference concentration",
+            "Rifampicin iv 600 mg (3 h)|P-gp|Reference concentration",
+            "Rifampicin iv 600 mg (0.5 h)|P-gp|Reference concentration",
+            "Rifampicin iv 450 mg (3 h)|P-gp|Reference concentration",
+            "Rifampicin iv 300 mg (3 h)|P-gp|Reference concentration",
+            "Rifampicin iv 300 mg (0.5 h)|P-gp|Reference concentration"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 1.41,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.1,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 14.1,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "Ref conc OATP1B1",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|OATP1B1|Reference concentration",
+            "Rifampicin po 450 mg|OATP1B1|Reference concentration",
+            "Rifampicin po 450 mg MD OD (7 days)|OATP1B1|Reference concentration",
+            "Rifampicin po 600 mg|OATP1B1|Reference concentration",
+            "Rifampicin po 600 mg MD OD (7 days)|OATP1B1|Reference concentration",
+            "Rifampicin po 600 mg MD OD (16 days)|OATP1B1|Reference concentration",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|OATP1B1|Reference concentration",
+            "Rifampicin iv 600 mg (3 h)|OATP1B1|Reference concentration",
+            "Rifampicin iv 600 mg (0.5 h)|OATP1B1|Reference concentration",
+            "Rifampicin iv 450 mg (3 h)|OATP1B1|Reference concentration",
+            "Rifampicin iv 300 mg (3 h)|OATP1B1|Reference concentration",
+            "Rifampicin iv 300 mg (0.5 h)|OATP1B1|Reference concentration"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 1.0,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.1,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 10.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "Relative expression P-gp Mucosa",
+          "Scaling": "Linear",
+          "UseAsFactor": true,
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 1.0
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.1
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 10.0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Name": "PI Hanke et al. 2018 (original start values)",
+      "Simulations": [
+        "Rifampicin po 300 mg",
+        "Rifampicin po 450 mg",
+        "Rifampicin po 450 mg MD OD (7 days)",
+        "Rifampicin po 600 mg",
+        "Rifampicin po 600 mg MD OD (7 days)",
+        "Rifampicin po 600 mg MD OD (16 days)",
+        "Rifampicin iv 600 mg (3 h) MD OD (7 days)",
+        "Rifampicin iv 600 mg (3 h)",
+        "Rifampicin iv 600 mg (0.5 h)",
+        "Rifampicin iv 450 mg (3 h)",
+        "Rifampicin iv 300 mg (3 h)",
+        "Rifampicin iv 300 mg (0.5 h)"
+      ],
+      "Configuration": {
+        "LLOQMode": "SimulationOutputAsObservedDataLLOQ",
+        "RemoveLLOQMode": "Never",
+        "CalculateJacobian": false,
+        "Algorithm": {
+          "Name": "Levenberg - Marquardt (MPFit)",
+          "Properties": [
+            {
+              "Name": "ftol",
+              "Value": 0.001
+            },
+            {
+              "Name": "xtol",
+              "Value": 1E-06
+            },
+            {
+              "Name": "gtol",
+              "Value": 1E-10
+            },
+            {
+              "Name": "stepfactor",
+              "Value": 100.0
+            },
+            {
+              "Name": "maxiter",
+              "Value": 200.0
+            },
+            {
+              "Name": "maxfev",
+              "Value": 0.0
+            },
+            {
+              "Name": "epsfcn",
+              "Value": 1E-09
+            }
+          ]
+        }
+      },
+      "OutputMappings": [
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin po 300 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Chouchane 1995 - Rifampicin Generic - Rifampicin - PO - 300 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 300 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Chouchane 1995 - Rimactan - Rifampicin - PO - 300 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 300 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Furesz 1970 - 300 mg - Rifampicin - PO - 300 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.75,
+          "Path": "Rifampicin po 450 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Blume 1989 - 450 mg REFERENZ - Rifampicin - PO - 450 mg - Plasma - agg. (n=8)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 450 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 450 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Furesz 1970 - 450 mg - Rifampicin - PO - 450 mg - Serum - agg. (n=13)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin po 450 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1972a - day 7 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.75,
+          "Path": "Rifampicin po 450 mg MD OD (7 days)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Urine - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Peloquin 1997 - 600 mg - Rifampicin - PO - 600 mg - Plasma - agg. (n=24)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Rifadine Tab - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Blume 1989 - 600 mg REFERENZ - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Serum - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Furesz 1970 - 600 mg - Rifampicin - PO - 600 mg - Serum - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 30.0,
+          "Path": "Rifampicin po 600 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Baneyx 2014 - Day 4 - 600 mg po MD - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 30.0,
+          "Path": "Rifampicin po 600 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Baneyx 2014 - Day 7 - 600 mg po MD - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Serum - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 5.0,
+          "Path": "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1977 - mean 600 mg MD - Rifampicin - IV - 600 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 600 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Urine - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin iv 600 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Acocella 1977 - mean 600 mg MD - Rifampicin - IV - 600 mg - Urine - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 600 mg (0.5 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "sanofi-aventis U.S. LLC. 2013 - 600 mg - Rifampicin - IV - 600 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 450 mg (3 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Nitti 1977 - 450 mg - Rifampicin - IV - 450 mg - Serum - agg. (n=3)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 450 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Nitti 1977 - 450 mg - Rifampicin - IV - 450 mg - Urine - agg. (n=3)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 300 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Nitti 1977 - 300 mg - Rifampicin - IV - 300 mg - Urine - agg. (n=2)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 300 mg (3 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Nitti 1977 - 300 mg - Rifampicin - IV - 300 mg - Serum - agg. (n=2)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 300 mg (0.5 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "sanofi-aventis U.S. LLC. 2013 - 300 mg - Rifampicin - IV - 300 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 8.0,
+          "Path": "Rifampicin po 600 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Peloquin 1997 - 600 mg - Rifampicin - PO - 600 mg - Plasma - agg. (n=24)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 15.0,
+          "Path": "Rifampicin iv 600 mg (3 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Serum - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.75,
+          "Path": "Rifampicin po 450 mg MD OD (7 days)|Organism|Gallbladder|Rifampicin",
+          "ObservedData": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Bile - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin po 450 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Urine - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 5.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Tab (Eon) - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Fold-change in concentration",
+          "ObservedData": "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Fold-change in concentration",
+          "ObservedData": "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Fold-change in concentration",
+          "ObservedData": "Westphal 2000 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)"
+        }
+      ],
+      "IdentificationParameters": [
+        {
+          "Name": "Lipophilicity",
+          "Scaling": "Linear",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Lipophilicity",
+            "Rifampicin po 450 mg|Rifampicin|Lipophilicity",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Lipophilicity",
+            "Rifampicin po 600 mg|Rifampicin|Lipophilicity",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Lipophilicity",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Lipophilicity"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 2.62,
+              "Unit": "Log Units"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 2.0,
+              "Unit": "Log Units"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 3.5,
+              "Unit": "Log Units"
+            }
+          ]
+        },
+        {
+          "Name": "P-gp kcat",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 450 mg|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 600 mg|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|P-gp-Collett 2004|kcat"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 1.16,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.01,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 500.0,
+              "Unit": "1/min"
+            }
+          ]
+        },
+        {
+          "Name": "OATP kcat",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 450 mg|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 600 mg|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|OATP1B1-Tirona 2003|kcat"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 12.7,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.01,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 500.0,
+              "Unit": "1/min"
+            }
+          ]
+        },
+        {
+          "Name": "Esterase kcat",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 450 mg|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 600 mg|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin-AADAC-Nakajima 2011|kcat"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 13.22,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.01,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 500.0,
+              "Unit": "1/min"
+            }
+          ]
+        },
+        {
+          "Name": "P int",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 450 mg|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 600 mg|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Specific intestinal permeability (transcellular)"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 1.66E-05,
+              "Unit": "cm/min"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 3.48E-07,
+              "Unit": "cm/min"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 0.00348,
+              "Unit": "cm/min"
+            }
+          ]
+        },
+        {
+          "Name": "Esterase t1/2 (liver)",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|AADAC|t1/2 (liver)",
+            "Rifampicin po 450 mg|AADAC|t1/2 (liver)",
+            "Rifampicin po 450 mg MD OD (7 days)|AADAC|t1/2 (liver)",
+            "Rifampicin po 600 mg|AADAC|t1/2 (liver)",
+            "Rifampicin po 600 mg MD OD (7 days)|AADAC|t1/2 (liver)",
+            "Rifampicin po 600 mg MD OD (16 days)|AADAC|t1/2 (liver)",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|AADAC|t1/2 (liver)",
+            "Rifampicin iv 600 mg (3 h)|AADAC|t1/2 (liver)",
+            "Rifampicin iv 600 mg (0.5 h)|AADAC|t1/2 (liver)",
+            "Rifampicin iv 450 mg (3 h)|AADAC|t1/2 (liver)",
+            "Rifampicin iv 300 mg (3 h)|AADAC|t1/2 (liver)",
+            "Rifampicin iv 300 mg (0.5 h)|AADAC|t1/2 (liver)"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 36.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 24.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 150.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "P-gp t1/2 (liver)",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|P-gp|t1/2 (liver)",
+            "Rifampicin po 450 mg|P-gp|t1/2 (liver)",
+            "Rifampicin po 450 mg MD OD (7 days)|P-gp|t1/2 (liver)",
+            "Rifampicin po 600 mg|P-gp|t1/2 (liver)",
+            "Rifampicin po 600 mg MD OD (7 days)|P-gp|t1/2 (liver)",
+            "Rifampicin po 600 mg MD OD (16 days)|P-gp|t1/2 (liver)",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|P-gp|t1/2 (liver)",
+            "Rifampicin iv 600 mg (3 h)|P-gp|t1/2 (liver)",
+            "Rifampicin iv 600 mg (0.5 h)|P-gp|t1/2 (liver)",
+            "Rifampicin iv 450 mg (3 h)|P-gp|t1/2 (liver)",
+            "Rifampicin iv 300 mg (3 h)|P-gp|t1/2 (liver)",
+            "Rifampicin iv 300 mg (0.5 h)|P-gp|t1/2 (liver)"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 36.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 24.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 150.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "OATP t1/2 (liver)",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|OATP1B1|t1/2 (liver)",
+            "Rifampicin po 450 mg|OATP1B1|t1/2 (liver)",
+            "Rifampicin po 450 mg MD OD (7 days)|OATP1B1|t1/2 (liver)",
+            "Rifampicin po 600 mg|OATP1B1|t1/2 (liver)",
+            "Rifampicin po 600 mg MD OD (7 days)|OATP1B1|t1/2 (liver)",
+            "Rifampicin po 600 mg MD OD (16 days)|OATP1B1|t1/2 (liver)",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|OATP1B1|t1/2 (liver)",
+            "Rifampicin iv 600 mg (3 h)|OATP1B1|t1/2 (liver)",
+            "Rifampicin iv 600 mg (0.5 h)|OATP1B1|t1/2 (liver)",
+            "Rifampicin iv 450 mg (3 h)|OATP1B1|t1/2 (liver)",
+            "Rifampicin iv 300 mg (3 h)|OATP1B1|t1/2 (liver)",
+            "Rifampicin iv 300 mg (0.5 h)|OATP1B1|t1/2 (liver)"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 36.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 24.0,
+              "Unit": "h"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 150.0,
+              "Unit": "h"
+            }
+          ]
+        },
+        {
+          "Name": "P-gp Emax",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 450 mg|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 600 mg|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|P-gp-Greiner 1999|Emax"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 2.5
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.01
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 25.0
+            }
+          ]
+        },
+        {
+          "Name": "P-gp EC50",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 450 mg|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 600 mg|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|P-gp-Greiner 1999|EC50"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.34,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.0001,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 1000.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "Esterase Emax",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 450 mg|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 600 mg|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|AADAC-Assumed|Emax"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 1.02
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.1
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 100.0
+            }
+          ]
+        },
+        {
+          "Name": "Esterase EC50",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 450 mg|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 600 mg|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|AADAC-Assumed|EC50"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.34,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.0001,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 1000.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "OATP Emax",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 450 mg|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 600 mg|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|OATP1B1-Dixit 2007|Emax"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.71
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.1
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 100.0
+            }
+          ]
+        },
+        {
+          "Name": "OATP EC50",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 450 mg|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 600 mg|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|OATP1B1-Dixit 2007|EC50"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.34,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.0001,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 1000.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "Solubility at reference pH",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 450 mg|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 600 mg|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Solubility at reference pH"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 2800.0,
+              "Unit": "mg/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 45.0,
+              "Unit": "mg/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 4500.0,
+              "Unit": "mg/l"
+            }
+          ]
+        },
+        {
+          "Name": "Fraction unbound (plasma, reference value)",
+          "Scaling": "Linear",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin po 450 mg|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin po 600 mg|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Fraction unbound (plasma, reference value)",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Fraction unbound (plasma, reference value)"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 17.0,
+              "Unit": "%"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 1.1,
+              "Unit": "%"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 100.0,
+              "Unit": "%"
+            }
+          ]
+        },
+        {
+          "Name": "Reference pH",
+          "Scaling": "Linear",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Reference pH",
+            "Rifampicin po 450 mg|Rifampicin|Reference pH",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Reference pH",
+            "Rifampicin po 600 mg|Rifampicin|Reference pH",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Reference pH",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Reference pH",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Reference pH",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Reference pH",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Reference pH",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Reference pH",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Reference pH",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Reference pH"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 7.5
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.0
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 14.0
+            }
+          ]
+        },
+        {
+          "Name": "Ref conc P-gp",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|P-gp|Reference concentration",
+            "Rifampicin po 450 mg|P-gp|Reference concentration",
+            "Rifampicin po 450 mg MD OD (7 days)|P-gp|Reference concentration",
+            "Rifampicin po 600 mg|P-gp|Reference concentration",
+            "Rifampicin po 600 mg MD OD (7 days)|P-gp|Reference concentration",
+            "Rifampicin po 600 mg MD OD (16 days)|P-gp|Reference concentration",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|P-gp|Reference concentration",
+            "Rifampicin iv 600 mg (3 h)|P-gp|Reference concentration",
+            "Rifampicin iv 600 mg (0.5 h)|P-gp|Reference concentration",
+            "Rifampicin iv 450 mg (3 h)|P-gp|Reference concentration",
+            "Rifampicin iv 300 mg (3 h)|P-gp|Reference concentration",
+            "Rifampicin iv 300 mg (0.5 h)|P-gp|Reference concentration"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 1.41,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.1,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 14.1,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "Ref conc OATP1B1",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|OATP1B1|Reference concentration",
+            "Rifampicin po 450 mg|OATP1B1|Reference concentration",
+            "Rifampicin po 450 mg MD OD (7 days)|OATP1B1|Reference concentration",
+            "Rifampicin po 600 mg|OATP1B1|Reference concentration",
+            "Rifampicin po 600 mg MD OD (7 days)|OATP1B1|Reference concentration",
+            "Rifampicin po 600 mg MD OD (16 days)|OATP1B1|Reference concentration",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|OATP1B1|Reference concentration",
+            "Rifampicin iv 600 mg (3 h)|OATP1B1|Reference concentration",
+            "Rifampicin iv 600 mg (0.5 h)|OATP1B1|Reference concentration",
+            "Rifampicin iv 450 mg (3 h)|OATP1B1|Reference concentration",
+            "Rifampicin iv 300 mg (3 h)|OATP1B1|Reference concentration",
+            "Rifampicin iv 300 mg (0.5 h)|OATP1B1|Reference concentration"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 1.0,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.1,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 10.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "Relative expression P-gp Mucosa",
+          "Scaling": "Linear",
+          "UseAsFactor": true,
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 300 mg|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 450 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin po 600 mg MD OD (16 days)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 600 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 450 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (3 h)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|SmallIntestine|Mucosa|UpperJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|SmallIntestine|Mucosa|LowerJejunum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|SmallIntestine|Mucosa|UpperIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|SmallIntestine|Mucosa|LowerIleum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonAscendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonTransversum|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonDescendens|Intracellular|P-gp|Relative expression",
+            "Rifampicin iv 300 mg (0.5 h)|Organism|LargeIntestine|Mucosa|ColonSigmoid|Intracellular|P-gp|Relative expression"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 1.0
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.1
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 10.0
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "Name": "PI OSP10",
+      "Simulations": [
+        "Rifampicin po 300 mg",
+        "Rifampicin po 450 mg",
+        "Rifampicin po 450 mg MD OD (7 days)",
+        "Rifampicin po 600 mg",
+        "Rifampicin po 600 mg MD OD (7 days)",
+        "Rifampicin po 600 mg MD OD (16 days)",
+        "Rifampicin iv 600 mg (3 h) MD OD (7 days)",
+        "Rifampicin iv 600 mg (3 h)",
+        "Rifampicin iv 600 mg (0.5 h)",
+        "Rifampicin iv 450 mg (3 h)",
+        "Rifampicin iv 300 mg (3 h)",
+        "Rifampicin iv 300 mg (0.5 h)",
+        "Rifampicin po 600 mg Chattopadhyay 2018"
+      ],
+      "Configuration": {
+        "LLOQMode": "SimulationOutputAsObservedDataLLOQ",
+        "RemoveLLOQMode": "Never",
+        "CalculateJacobian": false,
+        "Algorithm": {
+          "Name": "Levenberg - Marquardt (MPFit)",
+          "Properties": [
+            {
+              "Name": "ftol",
+              "Value": 0.001
+            },
+            {
+              "Name": "xtol",
+              "Value": 1E-06
+            },
+            {
+              "Name": "gtol",
+              "Value": 1E-10
+            },
+            {
+              "Name": "stepfactor",
+              "Value": 100.0
+            },
+            {
+              "Name": "maxiter",
+              "Value": 200.0
+            },
+            {
+              "Name": "maxfev",
+              "Value": 0.0
+            },
+            {
+              "Name": "epsfcn",
+              "Value": 1E-09
+            }
+          ]
+        }
+      },
+      "OutputMappings": [
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin po 300 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Chouchane 1995 - Rifampicin Generic - Rifampicin - PO - 300 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 300 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Chouchane 1995 - Rimactan - Rifampicin - PO - 300 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 300 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Furesz 1970 - 300 mg - Rifampicin - PO - 300 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.75,
+          "Path": "Rifampicin po 450 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Blume 1989 - 450 mg REFERENZ - Rifampicin - PO - 450 mg - Plasma - agg. (n=8)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 450 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 450 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Furesz 1970 - 450 mg - Rifampicin - PO - 450 mg - Serum - agg. (n=13)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin po 450 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1972a - day 7 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.75,
+          "Path": "Rifampicin po 450 mg MD OD (7 days)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Urine - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Peloquin 1997 - 600 mg - Rifampicin - PO - 600 mg - Plasma - agg. (n=24)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Rifadine Tab - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Blume 1989 - 600 mg REFERENZ - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Serum - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Furesz 1970 - 600 mg - Rifampicin - PO - 600 mg - Serum - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 10.0,
+          "Path": "Rifampicin po 600 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Baneyx 2014 - Day 4 - 600 mg po MD - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 10.0,
+          "Path": "Rifampicin po 600 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Baneyx 2014 - Day 7 - 600 mg po MD - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Serum - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 5.0,
+          "Path": "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1977 - mean 600 mg MD - Rifampicin - IV - 600 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 600 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Urine - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin iv 600 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Acocella 1977 - mean 600 mg MD - Rifampicin - IV - 600 mg - Urine - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 600 mg (0.5 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "sanofi-aventis U.S. LLC. 2013 - 600 mg - Rifampicin - IV - 600 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 450 mg (3 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Nitti 1977 - 450 mg - Rifampicin - IV - 450 mg - Serum - agg. (n=3)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 450 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Nitti 1977 - 450 mg - Rifampicin - IV - 450 mg - Urine - agg. (n=3)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 300 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Nitti 1977 - 300 mg - Rifampicin - IV - 300 mg - Urine - agg. (n=2)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 300 mg (3 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Nitti 1977 - 300 mg - Rifampicin - IV - 300 mg - Serum - agg. (n=2)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin iv 300 mg (0.5 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "sanofi-aventis U.S. LLC. 2013 - 300 mg - Rifampicin - IV - 300 mg - Plasma - agg. (n=12)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 8.0,
+          "Path": "Rifampicin po 600 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Peloquin 1997 - 600 mg - Rifampicin - PO - 600 mg - Plasma - agg. (n=24)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 15.0,
+          "Path": "Rifampicin iv 600 mg (3 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Serum - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.75,
+          "Path": "Rifampicin po 450 mg MD OD (7 days)|Organism|Gallbladder|Rifampicin",
+          "ObservedData": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Bile - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Path": "Rifampicin po 450 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg|Organism|Kidney|Urine|Rifampicin",
+          "ObservedData": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Urine - agg. (n=6)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 5.0,
+          "Path": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Tab (Eon) - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Fold-change in concentration",
+          "ObservedData": "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Fold-change in concentration",
+          "ObservedData": "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 0.0,
+          "Path": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Fold-change in concentration",
+          "ObservedData": "Westphal 2000 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)"
+        },
+        {
+          "Scaling": "Log",
+          "Weight": 100.0,
+          "Path": "Rifampicin po 600 mg Chattopadhyay 2018|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+          "ObservedData": "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)"
+        }
+      ],
+      "IdentificationParameters": [
+        {
+          "Name": "Lipophilicity",
+          "Scaling": "Linear",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Lipophilicity",
+            "Rifampicin po 450 mg|Rifampicin|Lipophilicity",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Lipophilicity",
+            "Rifampicin po 600 mg|Rifampicin|Lipophilicity",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Lipophilicity",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Lipophilicity",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Lipophilicity",
+            "Rifampicin po 600 mg Chattopadhyay 2018|Rifampicin|Lipophilicity"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 2.5,
+              "Unit": "Log Units"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 2.0,
+              "Unit": "Log Units"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 3.5,
+              "Unit": "Log Units"
+            }
+          ]
+        },
+        {
+          "Name": "P-gp kcat",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 450 mg|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 600 mg|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|P-gp-Collett 2004|kcat",
+            "Rifampicin po 600 mg Chattopadhyay 2018|Rifampicin|P-gp-Collett 2004|kcat"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.6088,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.01,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 500.0,
+              "Unit": "1/min"
+            }
+          ]
+        },
+        {
+          "Name": "OATP kcat",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 450 mg|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 600 mg|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|OATP1B1-Tirona 2003|kcat",
+            "Rifampicin po 600 mg Chattopadhyay 2018|Rifampicin|OATP1B1-Tirona 2003|kcat"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 7.796,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.01,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 500.0,
+              "Unit": "1/min"
+            }
+          ]
+        },
+        {
+          "Name": "Esterase kcat",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 450 mg|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 600 mg|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin-AADAC-Nakajima 2011|kcat",
+            "Rifampicin po 600 mg Chattopadhyay 2018|Rifampicin-AADAC-Nakajima 2011|kcat"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 9.865,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.01,
+              "Unit": "1/min"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 500.0,
+              "Unit": "1/min"
+            }
+          ]
+        },
+        {
+          "Name": "P int",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 450 mg|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 600 mg|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Specific intestinal permeability (transcellular)",
+            "Rifampicin po 600 mg Chattopadhyay 2018|Rifampicin|Specific intestinal permeability (transcellular)"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 1.24E-05,
+              "Unit": "cm/min"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 3.48E-07,
+              "Unit": "cm/min"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 0.00348,
+              "Unit": "cm/min"
+            }
+          ]
+        },
+        {
+          "Name": "P-gp Emax",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 450 mg|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 600 mg|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|P-gp-Greiner 1999|Emax",
+            "Rifampicin po 600 mg Chattopadhyay 2018|Rifampicin|P-gp-Greiner 1999|Emax"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 2.5
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.01
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 25.0
+            }
+          ]
+        },
+        {
+          "Name": "P-gp EC50",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 450 mg|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 600 mg|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|P-gp-Greiner 1999|EC50",
+            "Rifampicin po 600 mg Chattopadhyay 2018|Rifampicin|P-gp-Greiner 1999|EC50"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.34,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.0001,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 1000.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "Esterase Emax",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 450 mg|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 600 mg|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|AADAC-Assumed|Emax",
+            "Rifampicin po 600 mg Chattopadhyay 2018|Rifampicin|AADAC-Assumed|Emax"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.985
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.1
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 100.0
+            }
+          ]
+        },
+        {
+          "Name": "Esterase EC50",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 450 mg|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 600 mg|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|AADAC-Assumed|EC50",
+            "Rifampicin po 600 mg Chattopadhyay 2018|Rifampicin|AADAC-Assumed|EC50"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.34,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.0001,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 1000.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "OATP Emax",
+          "Scaling": "Log",
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 450 mg|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 600 mg|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|OATP1B1-Dixit 2007|Emax",
+            "Rifampicin po 600 mg Chattopadhyay 2018|Rifampicin|OATP1B1-Dixit 2007|Emax"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.383
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.1
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 100.0
+            }
+          ]
+        },
+        {
+          "Name": "OATP EC50",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 450 mg|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 600 mg|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|OATP1B1-Dixit 2007|EC50",
+            "Rifampicin po 600 mg Chattopadhyay 2018|Rifampicin|OATP1B1-Dixit 2007|EC50"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 0.34,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 0.0001,
+              "Unit": "µmol/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 1000.0,
+              "Unit": "µmol/l"
+            }
+          ]
+        },
+        {
+          "Name": "Solubility at reference pH",
+          "Scaling": "Log",
+          "IsFixed": true,
+          "LinkedParameters": [
+            "Rifampicin po 300 mg|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 450 mg|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 450 mg MD OD (7 days)|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 600 mg|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 600 mg MD OD (7 days)|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 600 mg MD OD (16 days)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 600 mg (3 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 600 mg (0.5 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 450 mg (3 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 300 mg (3 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin iv 300 mg (0.5 h)|Rifampicin|Solubility at reference pH",
+            "Rifampicin po 600 mg Chattopadhyay 2018|Rifampicin|Solubility at reference pH"
+          ],
+          "Parameters": [
+            {
+              "Name": "Start value",
+              "Value": 2800.0,
+              "Unit": "mg/l"
+            },
+            {
+              "Name": "MinValue",
+              "Value": 45.0,
+              "Unit": "mg/l"
+            },
+            {
+              "Name": "MaxValue",
+              "Value": 4500.0,
+              "Unit": "mg/l"
+            }
+          ]
+        }
+      ],
+      "Analyses": [
+        {
+          "Name": "Time Profile",
+          "Type": "ParameterIdentificationTimeProfileChart",
+          "Chart": {
+            "Axes": [
+              {
+                "Unit": "h",
+                "Dimension": "Time",
+                "Type": "X",
+                "GridLines": false,
+                "Visible": true,
+                "DefaultColor": "#FFFFFF",
+                "DefaultLineStyle": "None",
+                "Scaling": "Linear",
+                "NumberMode": "Normal"
+              },
+              {
+                "Unit": "mg/l",
+                "Dimension": "Concentration (mass)",
+                "Type": "Y",
+                "GridLines": false,
+                "Visible": true,
+                "DefaultColor": "#FFFFFF",
+                "DefaultLineStyle": "Solid",
+                "Scaling": "Log",
+                "NumberMode": "Normal"
+              },
+              {
+                "Unit": "kg",
+                "Dimension": "Mass",
+                "Type": "Y2",
+                "GridLines": false,
+                "Visible": true,
+                "DefaultColor": "#FFFFFF",
+                "DefaultLineStyle": "Dash",
+                "Scaling": "Log",
+                "NumberMode": "Normal"
+              }
+            ],
+            "Curves": [
+              {
+                "Name": "Chouchane 1995 - Rifampicin Generic - Rifampicin - PO - 300 mg - Plasma - agg. (n=12)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Chouchane 1995 - Rifampicin Generic - Rifampicin - PO - 300 mg - Plasma - agg. (n=12)|Time",
+                "Y": "Chouchane 1995 - Rifampicin Generic - Rifampicin - PO - 300 mg - Plasma - agg. (n=12)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#FF0000",
+                  "LegendIndex": 1,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Chouchane 1995 - Rimactan - Rifampicin - PO - 300 mg - Plasma - agg. (n=12)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Chouchane 1995 - Rimactan - Rifampicin - PO - 300 mg - Plasma - agg. (n=12)|Time",
+                "Y": "Chouchane 1995 - Rimactan - Rifampicin - PO - 300 mg - Plasma - agg. (n=12)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#FF0000",
+                  "LegendIndex": 2,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Furesz 1970 - 300 mg - Rifampicin - PO - 300 mg - Serum - agg. (n=5)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Furesz 1970 - 300 mg - Rifampicin - PO - 300 mg - Serum - agg. (n=5)|Time",
+                "Y": "Furesz 1970 - 300 mg - Rifampicin - PO - 300 mg - Serum - agg. (n=5)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#FF0000",
+                  "LegendIndex": 3,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Blume 1989 - 450 mg REFERENZ - Rifampicin - PO - 450 mg - Plasma - agg. (n=8)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Blume 1989 - 450 mg REFERENZ - Rifampicin - PO - 450 mg - Plasma - agg. (n=8)|Time",
+                "Y": "Blume 1989 - 450 mg REFERENZ - Rifampicin - PO - 450 mg - Plasma - agg. (n=8)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#0000FF",
+                  "LegendIndex": 4,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)|Time",
+                "Y": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#0000FF",
+                  "LegendIndex": 5,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Furesz 1970 - 450 mg - Rifampicin - PO - 450 mg - Serum - agg. (n=13)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Furesz 1970 - 450 mg - Rifampicin - PO - 450 mg - Serum - agg. (n=13)|Time",
+                "Y": "Furesz 1970 - 450 mg - Rifampicin - PO - 450 mg - Serum - agg. (n=13)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#0000FF",
+                  "LegendIndex": 6,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Acocella 1972a - day 7 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Acocella 1972a - day 7 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)|Time",
+                "Y": "Acocella 1972a - day 7 - Rifampicin - PO - 450 mg - Serum - agg. (n=5)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#008000",
+                  "LegendIndex": 7,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Urine - agg. (n=5)-Rifampicin-Kidney-Urine-ArithmeticMean",
+                "X": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Urine - agg. (n=5)|Time",
+                "Y": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Urine - agg. (n=5)|ObservedData|Kidney|Urine|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "VisibleInLegend": false,
+                  "Color": "#FF00FF",
+                  "LegendIndex": 8,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Peloquin 1997 - 600 mg - Rifampicin - PO - 600 mg - Plasma - agg. (n=24)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Peloquin 1997 - 600 mg - Rifampicin - PO - 600 mg - Plasma - agg. (n=24)|Time",
+                "Y": "Peloquin 1997 - 600 mg - Rifampicin - PO - 600 mg - Plasma - agg. (n=24)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#FF8000",
+                  "LegendIndex": 9,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Rifadine Tab - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Rifadine Tab - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)|Time",
+                "Y": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Rifadine Tab - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#FF8000",
+                  "LegendIndex": 10,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Blume 1989 - 600 mg REFERENZ - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Blume 1989 - 600 mg REFERENZ - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)|Time",
+                "Y": "Blume 1989 - 600 mg REFERENZ - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#FF8000",
+                  "LegendIndex": 11,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Serum - agg. (n=6)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Serum - agg. (n=6)|Time",
+                "Y": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Serum - agg. (n=6)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#FF8000",
+                  "LegendIndex": 12,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Furesz 1970 - 600 mg - Rifampicin - PO - 600 mg - Serum - agg. (n=12)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Furesz 1970 - 600 mg - Rifampicin - PO - 600 mg - Serum - agg. (n=12)|Time",
+                "Y": "Furesz 1970 - 600 mg - Rifampicin - PO - 600 mg - Serum - agg. (n=12)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#FF8000",
+                  "LegendIndex": 13,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Tab (Eon) - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Tab (Eon) - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)|Time",
+                "Y": "Eon Labs Manufacturing, Inc. 1997 - 2X300mg Tab (Eon) - Rifampicin - PO - 600 mg - Plasma - agg. (n=36)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#FF8000",
+                  "LegendIndex": 14,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Baneyx 2014 - Day 4 - 600 mg po MD - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Baneyx 2014 - Day 4 - 600 mg po MD - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)|Time",
+                "Y": "Baneyx 2014 - Day 4 - 600 mg po MD - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#00C0C0",
+                  "LegendIndex": 15,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Baneyx 2014 - Day 7 - 600 mg po MD - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Baneyx 2014 - Day 7 - 600 mg po MD - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)|Time",
+                "Y": "Baneyx 2014 - Day 7 - 600 mg po MD - Rifampicin - PO - 600 mg - Plasma - agg. (n=12)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#00C0C0",
+                  "LegendIndex": 16,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Serum - agg. (n=6)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Serum - agg. (n=6)|Time",
+                "Y": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Serum - agg. (n=6)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#C000C0",
+                  "LegendIndex": 17,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Acocella 1977 - mean 600 mg MD - Rifampicin - IV - 600 mg - Serum - agg. (n=5)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Acocella 1977 - mean 600 mg MD - Rifampicin - IV - 600 mg - Serum - agg. (n=5)|Time",
+                "Y": "Acocella 1977 - mean 600 mg MD - Rifampicin - IV - 600 mg - Serum - agg. (n=5)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#C000C0",
+                  "LegendIndex": 18,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Urine - agg. (n=6)-Rifampicin-Kidney-Urine-ArithmeticMean",
+                "X": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Urine - agg. (n=6)|Time",
+                "Y": "Nitti 1977 - 600 mg - Rifampicin - IV - 600 mg - Urine - agg. (n=6)|ObservedData|Kidney|Urine|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "VisibleInLegend": false,
+                  "Color": "#C04000",
+                  "LegendIndex": 19,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Acocella 1977 - mean 600 mg MD - Rifampicin - IV - 600 mg - Urine - agg. (n=5)-Rifampicin-Kidney-Urine-ArithmeticMean",
+                "X": "Acocella 1977 - mean 600 mg MD - Rifampicin - IV - 600 mg - Urine - agg. (n=5)|Time",
+                "Y": "Acocella 1977 - mean 600 mg MD - Rifampicin - IV - 600 mg - Urine - agg. (n=5)|ObservedData|Kidney|Urine|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "VisibleInLegend": false,
+                  "Color": "#C04000",
+                  "LegendIndex": 20,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "sanofi-aventis U.S. LLC. 2013 - 600 mg - Rifampicin - IV - 600 mg - Plasma - agg. (n=12)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "sanofi-aventis U.S. LLC. 2013 - 600 mg - Rifampicin - IV - 600 mg - Plasma - agg. (n=12)|Time",
+                "Y": "sanofi-aventis U.S. LLC. 2013 - 600 mg - Rifampicin - IV - 600 mg - Plasma - agg. (n=12)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#00FF00",
+                  "LegendIndex": 21,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Nitti 1977 - 450 mg - Rifampicin - IV - 450 mg - Serum - agg. (n=3)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Nitti 1977 - 450 mg - Rifampicin - IV - 450 mg - Serum - agg. (n=3)|Time",
+                "Y": "Nitti 1977 - 450 mg - Rifampicin - IV - 450 mg - Serum - agg. (n=3)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#808080",
+                  "LegendIndex": 22,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Nitti 1977 - 450 mg - Rifampicin - IV - 450 mg - Urine - agg. (n=3)-Rifampicin-Kidney-Urine-ArithmeticMean",
+                "X": "Nitti 1977 - 450 mg - Rifampicin - IV - 450 mg - Urine - agg. (n=3)|Time",
+                "Y": "Nitti 1977 - 450 mg - Rifampicin - IV - 450 mg - Urine - agg. (n=3)|ObservedData|Kidney|Urine|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "VisibleInLegend": false,
+                  "Color": "#C0C000",
+                  "LegendIndex": 23,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Nitti 1977 - 300 mg - Rifampicin - IV - 300 mg - Urine - agg. (n=2)-Rifampicin-Kidney-Urine-ArithmeticMean",
+                "X": "Nitti 1977 - 300 mg - Rifampicin - IV - 300 mg - Urine - agg. (n=2)|Time",
+                "Y": "Nitti 1977 - 300 mg - Rifampicin - IV - 300 mg - Urine - agg. (n=2)|ObservedData|Kidney|Urine|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "VisibleInLegend": false,
+                  "Color": "#8080FF",
+                  "LegendIndex": 24,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Nitti 1977 - 300 mg - Rifampicin - IV - 300 mg - Serum - agg. (n=2)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "Nitti 1977 - 300 mg - Rifampicin - IV - 300 mg - Serum - agg. (n=2)|Time",
+                "Y": "Nitti 1977 - 300 mg - Rifampicin - IV - 300 mg - Serum - agg. (n=2)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#0000C0",
+                  "LegendIndex": 25,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "sanofi-aventis U.S. LLC. 2013 - 300 mg - Rifampicin - IV - 300 mg - Plasma - agg. (n=12)-Rifampicin-Peripheral Venous Blood-Plasma-ArithmeticMean",
+                "X": "sanofi-aventis U.S. LLC. 2013 - 300 mg - Rifampicin - IV - 300 mg - Plasma - agg. (n=12)|Time",
+                "Y": "sanofi-aventis U.S. LLC. 2013 - 300 mg - Rifampicin - IV - 300 mg - Plasma - agg. (n=12)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#00C000",
+                  "LegendIndex": 26,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Bile - agg. (n=5)-Rifampicin-Liver-Undefined-ArithmeticMean",
+                "X": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Bile - agg. (n=5)|Time",
+                "Y": "Acocella 1972a - day 1 - Rifampicin - PO - 450 mg - Bile - agg. (n=5)|ObservedData|Liver|Undefined|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "VisibleInLegend": false,
+                  "Color": "#C00000",
+                  "LegendIndex": 27,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Urine - agg. (n=6)-Rifampicin-Kidney-Urine-ArithmeticMean",
+                "X": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Urine - agg. (n=6)|Time",
+                "Y": "Acocella 1972b - normal subjects - Rifampicin - PO - 600 mg - Urine - agg. (n=6)|ObservedData|Kidney|Urine|Rifampicin|ArithmeticMean",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "VisibleInLegend": false,
+                  "Color": "#FFFF00",
+                  "LegendIndex": 28,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Intracellular - agg. (n=8)-ObservedData-Duodenum-Intracellular-CYP3A4-ArithmeticMean",
+                "X": "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|Time",
+                "Y": "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|ObservedData|Duodenum|Intracellular|CYP3A4|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#008080",
+                  "LegendIndex": 29,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Intracellular - agg. (n=8)-ObservedData-Duodenum-Intracellular-P-gp-ArithmeticMean",
+                "X": "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|Time",
+                "Y": "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|ObservedData|Duodenum|Intracellular|P-gp|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#800080",
+                  "LegendIndex": 30,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Intracellular - agg. (n=8)-ObservedData-Duodenum-Intracellular-P-gp-ArithmeticMean",
+                "X": "Westphal 2000 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|Time",
+                "Y": "Westphal 2000 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|ObservedData|Duodenum|Intracellular|P-gp|ArithmeticMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#800080",
+                  "LegendIndex": 31,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)-Rifampicin-Peripheral Venous Blood-Plasma-GeometricMean",
+                "X": "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)|Time",
+                "Y": "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|GeometricMean",
+                "CurveOptions": {
+                  "VisibleInLegend": false,
+                  "Color": "#804040",
+                  "LegendIndex": 32,
+                  "LineStyle": "None",
+                  "Symbol": "Circle"
+                }
+              },
+              {
+                "Name": "Rifampicin iv 600 mg (3 h) MD OD (7 days)-Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+                "X": "Time",
+                "Y": "Rifampicin iv 600 mg (3 h) MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+                "CurveOptions": {
+                  "Color": "#C000C0",
+                  "LegendIndex": 33
+                }
+              },
+              {
+                "Name": "Rifampicin po 300 mg-Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+                "X": "Time",
+                "Y": "Rifampicin po 300 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+                "CurveOptions": {
+                  "Color": "#FF0000",
+                  "LegendIndex": 34
+                }
+              },
+              {
+                "Name": "Rifampicin po 450 mg-Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+                "X": "Time",
+                "Y": "Rifampicin po 450 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+                "CurveOptions": {
+                  "Color": "#0000FF",
+                  "LegendIndex": 35
+                }
+              },
+              {
+                "Name": "Rifampicin po 600 mg-Rifampicin-Kidney-Urine-Amount in container",
+                "X": "Time",
+                "Y": "Rifampicin po 600 mg|Organism|Kidney|Urine|Rifampicin",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "Color": "#FFFF00",
+                  "LegendIndex": 36,
+                  "LineStyle": "Dash"
+                }
+              },
+              {
+                "Name": "Rifampicin po 600 mg-Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+                "X": "Time",
+                "Y": "Rifampicin po 600 mg|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+                "CurveOptions": {
+                  "Color": "#FF8000",
+                  "LegendIndex": 37
+                }
+              },
+              {
+                "Name": "Rifampicin iv 600 mg (3 h)-Rifampicin-Kidney-Urine-Amount in container",
+                "X": "Time",
+                "Y": "Rifampicin iv 600 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "Color": "#C04000",
+                  "LegendIndex": 38,
+                  "LineStyle": "Dash"
+                }
+              },
+              {
+                "Name": "Rifampicin iv 600 mg (3 h)-Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+                "X": "Time",
+                "Y": "Rifampicin iv 600 mg (3 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+                "CurveOptions": {
+                  "Color": "#C00000",
+                  "LegendIndex": 39
+                }
+              },
+              {
+                "Name": "Rifampicin iv 300 mg (3 h)-Rifampicin-Kidney-Urine-Amount in container",
+                "X": "Time",
+                "Y": "Rifampicin iv 300 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "Color": "#8080FF",
+                  "LegendIndex": 40,
+                  "LineStyle": "Dash"
+                }
+              },
+              {
+                "Name": "Rifampicin iv 300 mg (3 h)-Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+                "X": "Time",
+                "Y": "Rifampicin iv 300 mg (3 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+                "CurveOptions": {
+                  "Color": "#0000C0",
+                  "LegendIndex": 41
+                }
+              },
+              {
+                "Name": "Rifampicin iv 600 mg (0.5 h)-Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+                "X": "Time",
+                "Y": "Rifampicin iv 600 mg (0.5 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+                "CurveOptions": {
+                  "Color": "#00FF00",
+                  "LegendIndex": 42
+                }
+              },
+              {
+                "Name": "Rifampicin iv 450 mg (3 h)-Rifampicin-Kidney-Urine-Amount in container",
+                "X": "Time",
+                "Y": "Rifampicin iv 450 mg (3 h)|Organism|Kidney|Urine|Rifampicin",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "Color": "#C0C000",
+                  "LegendIndex": 43,
+                  "LineStyle": "Dash"
+                }
+              },
+              {
+                "Name": "Rifampicin iv 450 mg (3 h)-Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+                "X": "Time",
+                "Y": "Rifampicin iv 450 mg (3 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+                "CurveOptions": {
+                  "Color": "#808080",
+                  "LegendIndex": 44
+                }
+              },
+              {
+                "Name": "Rifampicin iv 300 mg (0.5 h)-Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+                "X": "Time",
+                "Y": "Rifampicin iv 300 mg (0.5 h)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+                "CurveOptions": {
+                  "Color": "#00C000",
+                  "LegendIndex": 45
+                }
+              },
+              {
+                "Name": "Rifampicin po 450 mg MD OD (7 days)-Rifampicin-Gallbladder-Amount in container",
+                "X": "Time",
+                "Y": "Rifampicin po 450 mg MD OD (7 days)|Organism|Gallbladder|Rifampicin",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "Color": "#C00000",
+                  "LegendIndex": 46,
+                  "LineStyle": "Dash"
+                }
+              },
+              {
+                "Name": "Rifampicin po 450 mg MD OD (7 days)-Rifampicin-Kidney-Urine-Amount in container",
+                "X": "Time",
+                "Y": "Rifampicin po 450 mg MD OD (7 days)|Organism|Kidney|Urine|Rifampicin",
+                "CurveOptions": {
+                  "yAxisType": "Y2",
+                  "Color": "#FF00FF",
+                  "LegendIndex": 47,
+                  "LineStyle": "Dash"
+                }
+              },
+              {
+                "Name": "Rifampicin po 450 mg MD OD (7 days)-Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+                "X": "Time",
+                "Y": "Rifampicin po 450 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+                "CurveOptions": {
+                  "Color": "#008000",
+                  "LegendIndex": 48
+                }
+              },
+              {
+                "Name": "Rifampicin po 600 mg MD OD (7 days)-Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+                "X": "Time",
+                "Y": "Rifampicin po 600 mg MD OD (7 days)|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+                "CurveOptions": {
+                  "Color": "#00C0C0",
+                  "LegendIndex": 49
+                }
+              },
+              {
+                "Name": "Rifampicin po 600 mg Chattopadhyay 2018-Rifampicin-Peripheral Venous Blood-Plasma-Concentration",
+                "X": "Time",
+                "Y": "Rifampicin po 600 mg Chattopadhyay 2018|Organism|PeripheralVenousBlood|Rifampicin|Plasma (Peripheral Venous Blood)",
+                "CurveOptions": {
+                  "Color": "#804040",
+                  "LegendIndex": 50
+                }
+              },
+              {
+                "Name": "Rifampicin po 600 mg MD OD (16 days)-CYP3A4-Duodenum-Intracellular-Fold-change in concentration",
+                "X": "Time",
+                "Y": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|CYP3A4|Fold-change in concentration",
+                "CurveOptions": {
+                  "Color": "#008080",
+                  "LegendIndex": 51
+                }
+              },
+              {
+                "Name": "Rifampicin po 600 mg MD OD (16 days)-P-gp-Duodenum-Intracellular-Fold-change in concentration",
+                "X": "Time",
+                "Y": "Rifampicin po 600 mg MD OD (16 days)|Organism|SmallIntestine|Mucosa|Duodenum|Intracellular|P-gp|Fold-change in concentration",
+                "CurveOptions": {
+                  "Color": "#800080",
+                  "LegendIndex": 52
+                }
+              }
+            ],
+            "Name": "Time Profile"
+          }
         }
       ]
     }
@@ -16517,6 +21779,536 @@
         "Dimension": "Time",
         "Unit": "h"
       }
+    },
+    {
+      "Name": "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)",
+      "ExtendedProperties": [
+        {
+          "Name": "DB Version",
+          "Value": "OSP DATABASE"
+        },
+        {
+          "Name": "ID",
+          "Value": 1359.0
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Greiner 1999"
+        },
+        {
+          "Name": "Reference",
+          "Value": "https://pubmed.ncbi.nlm.nih.gov/10411543/"
+        },
+        {
+          "Name": "Source",
+          "Value": "Text"
+        },
+        {
+          "Name": "Grouping",
+          "Value": "CYP3A4 western blot duodenal biopsy (fold-change)"
+        },
+        {
+          "Name": "Data type",
+          "Value": "aggregated"
+        },
+        {
+          "Name": "N",
+          "Value": 8.0
+        },
+        {
+          "Name": "Molecule",
+          "Value": "CYP3A4"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Duodenum"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Intracellular"
+        },
+        {
+          "Name": "Route",
+          "Value": "PO"
+        },
+        {
+          "Name": "Dose",
+          "Value": "600 mg"
+        },
+        {
+          "Name": "Times of Administration [h]",
+          "Value": "S0-T24-R16"
+        },
+        {
+          "Name": "Formulation",
+          "Value": "."
+        },
+        {
+          "Name": "Food state",
+          "Value": "."
+        },
+        {
+          "Name": "Comment",
+          "Value": "."
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Avg",
+          "RelatedColumns": [
+            {
+              "Name": "Var",
+              "QuantityInfo": {
+                "Name": "Var",
+                "Path": "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|ObservedData|Duodenum|Intracellular|CYP3A4|ArithmeticStdDev"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "ArithmeticStdDev",
+                "Date": "0001-01-01T00:00:00",
+                "MolWeight": 57318.7
+              },
+              "Values": [
+                2.7
+              ],
+              "Dimension": "Fraction"
+            }
+          ],
+          "QuantityInfo": {
+            "Name": "Avg",
+            "Path": "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|ObservedData|Duodenum|Intracellular|CYP3A4|ArithmeticMean"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "Date": "0001-01-01T00:00:00",
+            "MolWeight": 57318.7
+          },
+          "Values": [
+            4.4
+          ],
+          "Dimension": "Fraction"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time",
+        "QuantityInfo": {
+          "Name": "Time",
+          "Path": "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|Time",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined",
+          "Date": "0001-01-01T00:00:00"
+        },
+        "Values": [
+          216.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)",
+      "ExtendedProperties": [
+        {
+          "Name": "DB Version",
+          "Value": "OSP DATABASE"
+        },
+        {
+          "Name": "ID",
+          "Value": 1363.0
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Chattopadhyay 2018"
+        },
+        {
+          "Name": "Reference",
+          "Value": "https://pubmed.ncbi.nlm.nih.gov/30171692/"
+        },
+        {
+          "Name": "Source",
+          "Value": "-"
+        },
+        {
+          "Name": "Grouping",
+          "Value": "Rifampicin"
+        },
+        {
+          "Name": "Data type",
+          "Value": "aggregated"
+        },
+        {
+          "Name": "N",
+          "Value": 11.0
+        },
+        {
+          "Name": "Molecule",
+          "Value": "Rifampicin"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Peripheral Venous Blood"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Plasma"
+        },
+        {
+          "Name": "Route",
+          "Value": "PO"
+        },
+        {
+          "Name": "Dose",
+          "Value": "600 mg"
+        },
+        {
+          "Name": "Times of Administration [h]",
+          "Value": "0-24-48-72-96-120-144-180-192-216-240"
+        },
+        {
+          "Name": "Formulation",
+          "Value": "."
+        },
+        {
+          "Name": "Food state",
+          "Value": "."
+        },
+        {
+          "Name": "Comment",
+          "Value": "."
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Avg",
+          "RelatedColumns": [
+            {
+              "Name": "Var",
+              "QuantityInfo": {
+                "Name": "Var",
+                "Path": "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|GeometricStdDev"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "GeometricStdDev",
+                "Date": "0001-01-01T00:00:00",
+                "MolWeight": 822.94
+              },
+              "Values": [
+                3.3379283,
+                2.112314,
+                1.69838774,
+                1.50916672,
+                1.70689964,
+                2.13327527
+              ],
+              "Dimension": "Dimensionless"
+            }
+          ],
+          "QuantityInfo": {
+            "Name": "Avg",
+            "Path": "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)|ObservedData|Peripheral Venous Blood|Plasma|Rifampicin|GeometricMean"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "Date": "0001-01-01T00:00:00",
+            "MolWeight": 822.94,
+            "LLOQ": 5E-09
+          },
+          "Values": [
+            0.0605684258,
+            0.02261017,
+            0.01402274,
+            0.008916791,
+            0.424754083,
+            0.0159085169
+          ],
+          "Dimension": "Concentration (mass)",
+          "Unit": "mg/l"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time",
+        "QuantityInfo": {
+          "Name": "Time",
+          "Path": "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)|Time",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined",
+          "Date": "0001-01-01T00:00:00"
+        },
+        "Values": [
+          24.0,
+          72.0,
+          144.0,
+          180.0,
+          192.0,
+          240.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)",
+      "ExtendedProperties": [
+        {
+          "Name": "DB Version",
+          "Value": "OSP DATABASE"
+        },
+        {
+          "Name": "ID",
+          "Value": 1358.0
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Greiner 1999"
+        },
+        {
+          "Name": "Reference",
+          "Value": "https://pubmed.ncbi.nlm.nih.gov/10411543/"
+        },
+        {
+          "Name": "Source",
+          "Value": "Text"
+        },
+        {
+          "Name": "Grouping",
+          "Value": "Pg-p western blot duodenal biopsy (fold-change)"
+        },
+        {
+          "Name": "Data type",
+          "Value": "aggregated"
+        },
+        {
+          "Name": "N",
+          "Value": 8.0
+        },
+        {
+          "Name": "Molecule",
+          "Value": "P-gp"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Duodenum"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Intracellular"
+        },
+        {
+          "Name": "Route",
+          "Value": "PO"
+        },
+        {
+          "Name": "Dose",
+          "Value": "600 mg"
+        },
+        {
+          "Name": "Times of Administration [h]",
+          "Value": "S0-T24-R16"
+        },
+        {
+          "Name": "Formulation",
+          "Value": "."
+        },
+        {
+          "Name": "Food state",
+          "Value": "."
+        },
+        {
+          "Name": "Comment",
+          "Value": "."
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Avg",
+          "RelatedColumns": [
+            {
+              "Name": "Var",
+              "QuantityInfo": {
+                "Name": "Var",
+                "Path": "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|ObservedData|Duodenum|Intracellular|P-gp|ArithmeticStdDev"
+              },
+              "DataInfo": {
+                "Origin": "ObservationAuxiliary",
+                "AuxiliaryType": "ArithmeticStdDev",
+                "Date": "0001-01-01T00:00:00",
+                "MolWeight": 141000.0
+              },
+              "Values": [
+                2.1
+              ],
+              "Dimension": "Fraction"
+            }
+          ],
+          "QuantityInfo": {
+            "Name": "Avg",
+            "Path": "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|ObservedData|Duodenum|Intracellular|P-gp|ArithmeticMean"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "Date": "0001-01-01T00:00:00",
+            "MolWeight": 141000.0
+          },
+          "Values": [
+            3.5
+          ],
+          "Dimension": "Fraction"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time",
+        "QuantityInfo": {
+          "Name": "Time",
+          "Path": "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|Time",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined",
+          "Date": "0001-01-01T00:00:00"
+        },
+        "Values": [
+          216.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
+    },
+    {
+      "Name": "Westphal 2000 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)",
+      "ExtendedProperties": [
+        {
+          "Name": "DB Version",
+          "Value": "OSP DATABASE"
+        },
+        {
+          "Name": "ID",
+          "Value": 1360.0
+        },
+        {
+          "Name": "Study Id",
+          "Value": "Westphal 2000"
+        },
+        {
+          "Name": "Reference",
+          "Value": "https://pubmed.ncbi.nlm.nih.gov/11061574/"
+        },
+        {
+          "Name": "Source",
+          "Value": "Text"
+        },
+        {
+          "Name": "Grouping",
+          "Value": "Pg-p western blot duodenal biopsy (fold-change)"
+        },
+        {
+          "Name": "Data type",
+          "Value": "aggregated"
+        },
+        {
+          "Name": "N",
+          "Value": 8.0
+        },
+        {
+          "Name": "Molecule",
+          "Value": "P-gp"
+        },
+        {
+          "Name": "Species",
+          "Value": "Human"
+        },
+        {
+          "Name": "Organ",
+          "Value": "Duodenum"
+        },
+        {
+          "Name": "Compartment",
+          "Value": "Intracellular"
+        },
+        {
+          "Name": "Route",
+          "Value": "PO"
+        },
+        {
+          "Name": "Dose",
+          "Value": "600 mg"
+        },
+        {
+          "Name": "Times of Administration [h]",
+          "Value": "S0-T24-R9"
+        },
+        {
+          "Name": "Formulation",
+          "Value": "."
+        },
+        {
+          "Name": "Food state",
+          "Value": "."
+        },
+        {
+          "Name": "Comment",
+          "Value": "."
+        }
+      ],
+      "Columns": [
+        {
+          "Name": "Avg",
+          "QuantityInfo": {
+            "Name": "Avg",
+            "Path": "Westphal 2000 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|ObservedData|Duodenum|Intracellular|P-gp|ArithmeticMean"
+          },
+          "DataInfo": {
+            "Origin": "Observation",
+            "AuxiliaryType": "Undefined",
+            "Date": "0001-01-01T00:00:00",
+            "MolWeight": 141000.0
+          },
+          "Values": [
+            4.2
+          ],
+          "Dimension": "Fraction"
+        }
+      ],
+      "BaseGrid": {
+        "Name": "Time",
+        "QuantityInfo": {
+          "Name": "Time",
+          "Path": "Westphal 2000 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)|Time",
+          "Type": "Time"
+        },
+        "DataInfo": {
+          "Origin": "BaseGrid",
+          "AuxiliaryType": "Undefined",
+          "Date": "0001-01-01T00:00:00"
+        },
+        "Values": [
+          179.0
+        ],
+        "Dimension": "Time",
+        "Unit": "h"
+      }
     }
   ],
   "ObservedDataClassifications": [
@@ -16689,6 +22481,25 @@
         "Furesz 1970 - 750 mg - Rifampicin - PO - 750 mg - Serum - agg. (n=10)",
         "Furesz 1970 - 900 mg - Rifampicin - PO - 900 mg - Serum - agg. (n=9)"
       ]
+    },
+    {
+      "Name": "Greiner 1999",
+      "Classifiables": [
+        "Greiner 1999 - CYP3A4 western blot duodenal biopsy (fold-change) - CYP3A4 - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)",
+        "Greiner 1999 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)"
+      ]
+    },
+    {
+      "Name": "Westphal 2000",
+      "Classifiables": [
+        "Westphal 2000 - Pg-p western blot duodenal biopsy (fold-change) - P-gp - PO - 600 mg - Duodenum|Intracellular - agg. (n=8)"
+      ]
+    },
+    {
+      "Name": "Chattopadhyay 2018",
+      "Classifiables": [
+        "Chattopadhyay 2018 - Rifampicin - Rifampicin - PO - 600 mg - Plasma - agg. (n=11)"
+      ]
     }
   ],
   "SimulationClassifications": [
@@ -16710,7 +22521,9 @@
         "Rifampicin po 300 mg",
         "Rifampicin po 450 mg",
         "Rifampicin po 600 mg",
-        "Rifampicin po 450 mg MD OD (7 days)"
+        "Rifampicin po 450 mg MD OD (7 days)",
+        "Rifampicin po 600 mg MD OD (16 days)",
+        "Rifampicin po 600 mg Chattopadhyay 2018"
       ]
     }
   ]


### PR DESCRIPTION
Update to PK-Sim 10 including update of GABRG2 and ATP1A2 reference concentrations and OATP1B1 kcat value to account for pk-sim 10 update in interstitial concentration calculations.